### PR TITLE
Feat: 공통 레이아웃 UI 컴포넌트 구현

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from './layouts';

--- a/src/components/layouts/Container.tsx
+++ b/src/components/layouts/Container.tsx
@@ -1,0 +1,32 @@
+import { breakpoints } from '@/styles';
+import { css } from '@emotion/react';
+import { ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+};
+
+const Container = ({ children }: Props) => {
+  return <div css={containerStyles}>{children}</div>;
+};
+
+export default Container;
+
+const containerStyles = css`
+  width: 100%;
+  height: 100vh;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background-color: #fff;
+
+  @media (min-width: ${breakpoints.mobile}) {
+    max-width: ${breakpoints.mobile};
+  }
+
+  @media (min-width: ${breakpoints.pc}) {
+    max-width: ${breakpoints.pc};
+    border: 2px solid red; // 구분용 - 삭제 예정
+  }
+`;

--- a/src/components/layouts/Footer.tsx
+++ b/src/components/layouts/Footer.tsx
@@ -1,0 +1,12 @@
+import { css } from '@emotion/react';
+
+const Footer = () => {
+  return <footer css={FooterContainer}>Footer</footer>;
+};
+
+export default Footer;
+
+const FooterContainer = css`
+  height: 83px;
+  background-color: yellow;
+`;

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,0 +1,12 @@
+import { css } from '@emotion/react';
+
+const Header = () => {
+  return <header css={HeaderContainer}>Header</header>;
+};
+
+export default Header;
+
+const HeaderContainer = css`
+  height: 52px;
+  background-color: red;
+`;

--- a/src/components/layouts/Main.tsx
+++ b/src/components/layouts/Main.tsx
@@ -1,0 +1,16 @@
+import { css } from '@emotion/react';
+import { ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+};
+
+const Main = ({ children }: Props) => {
+  return <main css={MainContainer}>{children}</main>;
+};
+
+export default Main;
+
+const MainContainer = css`
+  flex: 1;
+`;

--- a/src/components/layouts/MainLayout.tsx
+++ b/src/components/layouts/MainLayout.tsx
@@ -1,0 +1,21 @@
+import Container from '@/components/layouts/Container';
+import Footer from '@/components/layouts/Footer';
+import Header from '@/components/layouts/Header';
+import Main from '@/components/layouts/Main';
+import { ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+};
+
+const MainLayout = ({ children }: Props) => {
+  return (
+    <Container>
+      <Header />
+      <Main>{children}</Main>
+      <Footer />
+    </Container>
+  );
+};
+
+export default MainLayout;

--- a/src/components/layouts/index.ts
+++ b/src/components/layouts/index.ts
@@ -1,0 +1,5 @@
+export { default as Container } from './Container';
+export { default as Footer } from './Footer';
+export { default as Header } from './Header';
+export { default as Main } from './Main';
+export { default as MainLayout } from './MainLayout';

--- a/src/styles/breakpoints.ts
+++ b/src/styles/breakpoints.ts
@@ -1,0 +1,4 @@
+export const breakpoints = {
+  mobile: '375px',
+  pc: '600px',
+};

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -2,6 +2,14 @@ import { css } from '@emotion/react';
 
 export const globalStyles = css`
   /* Reset CSS */
+  * {
+    box-sizing: border-box;
+  }
+
+  body {
+    background-color: #fffef6;
+  }
+
   html,
   body,
   div,

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,0 +1,2 @@
+export { breakpoints } from './breakpoints';
+export { globalStyles } from './globalStyles';


### PR DESCRIPTION
## 작업 사항
- layouts 폴더 분리
- Container / Header / Footer 컴포넌트 추가
- barrel export로 index 내보내기 적용

### 스크린샷
<img width="480" alt="issue9" src="https://github.com/user-attachments/assets/3a6fd6d2-7a5c-4652-b881-55ecd8342204">

- 구분을 위한 스타일 적용중으로 추후 제거 예정

### 추가 정보
`layouts` 폴더에 관련 컴포넌트를 모두 두었지만, 재사용성 여부에 따라 common으로 분리될 수 있습니다.

## 관련 이슈
close #9 