### PR TITLE
Feat: 로그인 성공 후 인증 정보 Store 저장 및 유지

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "axios": "^1.7.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.26.2"
+    "react-router-dom": "^6.26.2",
+    "zustand": "5.0.0-rc.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-router-dom:
         specifier: ^6.26.2
         version: 6.26.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      zustand:
+        specifier: 5.0.0-rc.2
+        version: 5.0.0-rc.2(@types/react@18.3.5)(react@18.3.1)
     devDependencies:
       '@eslint/js':
         specifier: ^9.9.0
@@ -1893,6 +1896,24 @@ packages:
   yoctocolors-cjs@2.1.2:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
+
+  zustand@5.0.0-rc.2:
+    resolution: {integrity: sha512-o2Nwuvnk8vQBX7CcHL8WfFkZNJdxB/VKeWw0tNglw8p4cypsZ3tRT7rTRTDNeUPFS0qaMBRSKe+fVwL5xpcE3A==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -3823,3 +3844,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.2: {}
+
+  zustand@5.0.0-rc.2(@types/react@18.3.5)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 18.3.5
+      react: 18.3.1

--- a/src/Pages/GroupDetailPage.tsx
+++ b/src/Pages/GroupDetailPage.tsx
@@ -1,5 +1,0 @@
-const GroupDetailPage = () => {
-  return <div>GroupDetailPage</div>;
-};
-
-export default GroupDetailPage;

--- a/src/Pages/LoginPage.tsx
+++ b/src/Pages/LoginPage.tsx
@@ -1,17 +1,24 @@
-import { generateTempSession } from '@/api/auth';
+import { generateTempSession, getUser } from '@/api/auth';
+import { useAuthStore } from '@/stores/auth';
 import { pcMediaQuery } from '@/styles/breakpoints';
 import { css } from '@emotion/react';
 import { useNavigate } from 'react-router-dom';
 
 const LoginPage = () => {
   const navigate = useNavigate();
+  const login = useAuthStore((state) => state.login);
   const handleGoogleLogin = async () => {
     try {
-      // TODO: 테스트 완료 후 구글 로그인창으로 변경 예정
+      // TODO: 테스트 완료 후 구글 로그인으로 변경 예정
       const response = await generateTempSession();
       if (response.status === 200) {
-        navigate('/');
+        const { data: user } = await getUser();
+        login(user);
+        navigate('/squad');
         return;
+      } else {
+        // TODO: 세션 발급 실패 에러 처리
+        console.error('Failed to generate session:', response.status);
       }
     } catch (error) {
       // TODO: 로그인 실패 에러 안내

--- a/src/Pages/MyGroupsPage.tsx
+++ b/src/Pages/MyGroupsPage.tsx
@@ -1,5 +1,0 @@
-const MyGroupsPage = () => {
-  return <div>MyGroupsPage</div>;
-};
-
-export default MyGroupsPage;

--- a/src/Pages/SquadDetailPage.tsx
+++ b/src/Pages/SquadDetailPage.tsx
@@ -1,0 +1,5 @@
+const SquadDetailPage = () => {
+  return <div>SquadDetailPage</div>;
+};
+
+export default SquadDetailPage;

--- a/src/Pages/SquadPage.tsx
+++ b/src/Pages/SquadPage.tsx
@@ -1,0 +1,5 @@
+const SquadPage = () => {
+  return <div>SquadPage</div>;
+};
+
+export default SquadPage;

--- a/src/Pages/index.ts
+++ b/src/Pages/index.ts
@@ -1,0 +1,6 @@
+export { default as GoogleOAuthLoginPage } from './GoogleOAuthLoginPage';
+export { default as HomePage } from './HomePage';
+export { default as LoginPage } from './LoginPage';
+export { default as MyPage } from './MyPage';
+export { default as SquadDetailPage } from './SquadDetailPage';
+export { default as SquadPage } from './SquadPage';

--- a/src/Router/router.tsx
+++ b/src/Router/router.tsx
@@ -1,12 +1,9 @@
 import App from '@/App';
 import { MainLayout } from '@/components';
 import LoginLayout from '@/components/layouts/LoginLayout';
+import { HomePage, LoginPage, MyPage, SquadDetailPage, SquadPage } from '@/Pages';
 import GoogleOAuthCallbackPage from '@/Pages/GoogleOAuthLoginPage';
-import GroupDetailPage from '@/Pages/GroupDetailPage';
-import HomePage from '@/Pages/HomePage';
-import LoginPage from '@/Pages/LoginPage';
-import MyGroupsPage from '@/Pages/MyGroupsPage';
-import MyPage from '@/Pages/MyPage';
+
 import { createBrowserRouter, Outlet } from 'react-router-dom';
 
 export const router = createBrowserRouter([
@@ -27,12 +24,12 @@ export const router = createBrowserRouter([
             element: <HomePage />,
           },
           {
-            path: '/my-groups',
-            element: <MyGroupsPage />,
+            path: '/squad',
+            element: <SquadPage />,
           },
           {
-            path: '/my-groups/:groupId',
-            element: <GroupDetailPage />,
+            path: '/squad/:groupId',
+            element: <SquadDetailPage />,
           },
           {
             path: '/me',

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,5 +1,5 @@
 import { instance } from '@/api';
-import { OAuthRequestParams, OAuthUrl } from '@/types/auth';
+import { OAuthRequestParams, OAuthUrl, User } from '@/types/auth';
 import { AxiosResponse } from 'axios';
 
 // 개발기용 임시 로그인 API
@@ -34,4 +34,9 @@ export const signInOrSignUp = async ({ oauthType, code, scope }: OAuthRequestPar
 
   const response = await instance.post('/api/auth/login', data);
   return response;
+};
+
+export const getUser = async (): Promise<{ data: User }> => {
+  const response = await instance.get('/api/members/me');
+  return response.data;
 };

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,0 +1,22 @@
+import { User } from '@/types/auth';
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type AuthStore = {
+  user: User | null;
+  login: (user: User) => void;
+  logout: () => void;
+};
+
+export const useAuthStore = create(
+  persist<AuthStore>(
+    (set) => ({
+      user: null,
+      login: (user: User) => set({ user }),
+      logout: () => set({ user: null }),
+    }),
+    {
+      name: 'auth-state',
+    },
+  ),
+);

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -13,3 +13,8 @@ export type OAuthRequestParams = {
   code: string;
   scope: string;
 };
+
+export type User = {
+  oauthType: OAuthType;
+  email: 'string';
+};


### PR DESCRIPTION
## 작업 사항
- zustand 설치
  - 인증 관련 store 생성
- 구글 로그인 성공 후 사용자 정보 조회 API 연동
- 인증된 사용자 정보 store 저장 및 유지

## 변경 사항
- 명칭 변경: group -> squad
- 페이지 내보내기 방법 변경

### 추가 정보
개발기용 임시 로그인으로 대체한 상태로 추후 변경 예정

## 관련 이슈
close #19 