### PR TITLE
Feat: 스쿼드 멤버 강퇴 기능 추가

### DIFF
--- a/src/apis/squad.ts
+++ b/src/apis/squad.ts
@@ -3,6 +3,7 @@ import {
   AssignSquadLeaderParamType,
   CreateSquadParamType,
   ExitAndDeleteSquadNameParamType,
+  RemoveUserFromSquadParamType,
   UpdateSquadNameParamType,
 } from '@/hooks/mutations';
 
@@ -53,5 +54,13 @@ export const assignSquadLeader: MutationFunction<ApiResponse<null>, AssignSquadL
   memberId,
 }): Promise<ApiResponse<null>> => {
   const response = await instance.put(`/api/squads/${squadId}/members/${memberId}`);
+  return response.data;
+};
+
+export const removeUserFromSquad: MutationFunction<ApiResponse<null>, RemoveUserFromSquadParamType> = async ({
+  squadId,
+  memberId,
+}) => {
+  const response = await instance.delete(`/api/squads/${squadId}/members/${memberId}`);
   return response.data;
 };

--- a/src/hooks/mutations/useRemoveUserFromSquad.tsx
+++ b/src/hooks/mutations/useRemoveUserFromSquad.tsx
@@ -1,0 +1,38 @@
+import { removeUserFromSquad } from '@/apis';
+import { ActionPrompt } from '@/components/common/Modal/ModalContents';
+
+import { MutateOptionsType, RemoveUserFromSquadParamType } from '@/hooks/mutations';
+import { useModal } from '@/hooks/useModal';
+import { ApiResponse, SquadMember } from '@/types';
+import { useMutation } from '@tanstack/react-query';
+
+const useRemoveUserFromSquad = (
+  squadId: number,
+  member: SquadMember,
+  options: MutateOptionsType<ApiResponse<null>, RemoveUserFromSquadParamType>,
+) => {
+  const { ModalContainer: RemoveUserActionPrompt, openModal } = useModal();
+  const { mutate: deleteSquadMutate } = useMutation({
+    mutationFn: removeUserFromSquad,
+    ...options,
+  });
+
+  const handleRemoveUser = async () => {
+    const removeInfo = {
+      text: '강퇴',
+      type: 'delete',
+      message: `${member.name}님을 강퇴하시겠어요?`,
+      displayCancel: true,
+    } as const;
+
+    const res = await openModal(ActionPrompt, undefined, removeInfo);
+    if (res.ok) {
+      deleteSquadMutate({ squadId, memberId: member.memberId });
+      console.log(member.memberId);
+    }
+  };
+
+  return { RemoveUserActionPrompt, handleRemoveUser };
+};
+
+export default useRemoveUserFromSquad;


### PR DESCRIPTION
## 작업 사항
- 스쿼드 멤버 강퇴 API 함수 작성
- 강퇴 관련 로직(mutate, modal 등) 커스텀훅으로 분리
- 스쿼드 사이드바 내 멤버 리스트 컴포넌트 구현
   - `나`를 최상위로 보이도록 정렬 로직 추가

## 관련 이슈
close #48 