### PR TITLE
Feat: Calendar 로직 구현 및 선택된 날짜의 투두리스트 조회 API 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@tanstack/react-query": "^5.56.2",
     "@tanstack/react-query-devtools": "^5.58.0",
     "axios": "^1.7.7",
+    "date-fns": "^4.1.0",
+    "es-toolkit": "^1.24.0",
     "react": "^18.3.1",
     "react-cookie": "^7.2.1",
     "react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       axios:
         specifier: ^1.7.7
         version: 1.7.7
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
+      es-toolkit:
+        specifier: ^1.24.0
+        version: 1.24.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1269,6 +1275,9 @@ packages:
     resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
     engines: {node: '>= 0.4'}
 
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
   debug@4.1.1:
     resolution: {integrity: sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==}
     deprecated: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
@@ -1385,6 +1394,9 @@ packages:
   es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.24.0:
+    resolution: {integrity: sha512-nZM+MRSGhKjCdjvqWEFr5Jns6vxoXtBcsl4/cEsGMgsMx8Z2ato4vBTGMUSIQBZJgEdKyNcgGh42yu9xiuNYtQ==}
 
   esbuild-android-64@0.14.47:
     resolution: {integrity: sha512-R13Bd9+tqLVFndncMHssZrPWe6/0Kpv2/dt4aA69soX4PRxlzsVpCvoJeFE8sOEoeVEiBkI0myjlkDodXlHa0g==}
@@ -4287,6 +4299,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.1
 
+  date-fns@4.1.0: {}
+
   debug@4.1.1:
     dependencies:
       ms: 2.1.3
@@ -4455,6 +4469,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.0.5
       is-symbol: 1.0.4
+
+  es-toolkit@1.24.0: {}
 
   esbuild-android-64@0.14.47:
     optional: true

--- a/src/components/common/Calendar/CalendarList.tsx
+++ b/src/components/common/Calendar/CalendarList.tsx
@@ -1,0 +1,124 @@
+import { useDayStore } from '@/stores/todo';
+import { scrollBarStyle } from '@/styles/globalStyles';
+import { getDaysInMonth } from '@/utils/getDaysInMonth';
+import { css, Theme, useTheme } from '@emotion/react';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { forwardRef, MouseEvent, useEffect, useMemo, useRef } from 'react';
+
+type Props = {
+  selectedDay: string;
+  onSelectDay: (date: string) => void;
+  currentMonth: Date;
+};
+
+const CalendarList = ({ selectedDay, onSelectDay, currentMonth }: Props) => {
+  const daysContainerRef = useRef<HTMLUListElement>(null);
+  const selectedDayRef = useRef<HTMLLIElement>(null);
+  const daysInCurrentMonth = useMemo(() => getDaysInMonth(new Date(currentMonth)), [currentMonth]);
+
+  const handleClick = (e: MouseEvent<HTMLUListElement>) => {
+    const target = (e.target as HTMLElement).closest('li');
+    if (target && target instanceof HTMLLIElement) {
+      const day = target.dataset.day;
+      if (selectedDay === day) return;
+      if (day) {
+        onSelectDay(day);
+        target.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+          inline: 'center',
+        });
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (selectedDayRef.current) {
+      selectedDayRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+        inline: 'center',
+      });
+    }
+  }, [selectedDay]);
+
+  return (
+    <ul css={calendarStyle} onClick={handleClick} ref={daysContainerRef}>
+      {daysInCurrentMonth.map((day) => (
+        <CalendarItem key={day} day={day} ref={day === selectedDay ? selectedDayRef : null} />
+      ))}
+    </ul>
+  );
+};
+
+export default CalendarList;
+
+const CalendarItem = forwardRef<HTMLLIElement, { day: string }>(({ day }, ref) => {
+  const theme = useTheme();
+  const selectedDay = useDayStore((state) => state.selectedDay);
+  const isSelected = selectedDay === day;
+  const isToday = format(new Date(), 'yyyy-MM-dd') === day;
+
+  return (
+    <li
+      key={day}
+      css={[
+        calendarItemStyle(theme, isSelected),
+        isSelected && selectedDateStyle,
+        isToday && todayStyle(theme, isSelected),
+      ]}
+      data-day={day}
+      ref={ref}
+    >
+      <span>{format(new Date(day), 'dd')}</span>
+      <span css={dayNameStyle}>{format(new Date(day), 'EEE', { locale: ko })}</span>
+    </li>
+  );
+});
+
+const calendarStyle = css`
+  display: flex;
+  gap: 4px;
+  margin: 8px 16px;
+  overflow-x: auto;
+
+  ${scrollBarStyle}
+`;
+
+const calendarItemStyle = (theme: Theme, isSelected: boolean) => css`
+  width: 32px;
+  height: 48px;
+  flex-shrink: 0;
+  border-radius: 14px;
+  color: ${theme.colors.text};
+  background-color: ${theme.colors.background.white};
+  border: 2px solid ${theme.colors.gray.gray100};
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+
+  :hover {
+    background-color: ${!isSelected && theme.colors.background.yellow};
+    cursor: ${isSelected && 'default'};
+  }
+`;
+
+const todayStyle = (theme: Theme, isSelected: boolean) => css`
+  color: ${isSelected ? 'white' : theme.colors.primary};
+  border: 2px solid ${theme.colors.primary};
+`;
+
+const selectedDateStyle = (theme: Theme) => css`
+  background-color: ${theme.colors.primary};
+  border: 2px solid ${theme.colors.primary};
+  color: white;
+`;
+
+const dayNameStyle = (theme: Theme) => css`
+  ${theme.typography.size_10}
+  font-weight: 500;
+`;

--- a/src/stores/todo.ts
+++ b/src/stores/todo.ts
@@ -1,3 +1,4 @@
+import { format } from 'date-fns';
 import { create } from 'zustand';
 
 type TodoState = {
@@ -8,4 +9,14 @@ type TodoState = {
 export const useTodoStore = create<TodoState>((set) => ({
   isTodoChanged: false,
   setIsTodoChanged: (changed) => set({ isTodoChanged: changed }),
+}));
+
+type DateState = {
+  selectedDay: string;
+  setSelectedDay: (date: string) => void;
+};
+
+export const useDayStore = create<DateState>((set) => ({
+  selectedDay: format(new Date(), 'yyyy-MM-dd'),
+  setSelectedDay: (day: string) => set({ selectedDay: day }),
 }));

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,3 +1,0 @@
-export const formatDate = (date: Date) => {
-  return date.toISOString().split('T')[0];
-};

--- a/src/utils/getDaysInMonth.ts
+++ b/src/utils/getDaysInMonth.ts
@@ -1,0 +1,9 @@
+import { eachDayOfInterval, endOfMonth, format, startOfMonth } from 'date-fns';
+
+export const getDaysInMonth = (date: Date) => {
+  const start = startOfMonth(date);
+  const end = endOfMonth(date);
+
+  const days = eachDayOfInterval({ start, end });
+  return days.map((day) => format(day, 'yyyy-MM-dd'));
+};


### PR DESCRIPTION
## 작업 사항
- 오늘 또는 선택한 날짜가 포함된 달의 일자 계산 함수 작성 (`getDaysInMonth`)
- 선택된 날짜 상태와 변경을 위한 store 생성
- 캘린더 관련 로직에 따라 스타일 적용

### 추가 정보
- #72 에서 사용된 `es-toolkit` 추가
- 이후 나의 투두리스트 조회 페이지 로직에 따라 `month` 선택과 `CalendarList` 컴포넌트는 리팩토링 될 수 있음

## 관련 이슈
close #73 