### PR TITLE
Feat: 투두 등록 API 연동

### DIFF
--- a/src/Pages/SquadDetailPage.tsx
+++ b/src/Pages/SquadDetailPage.tsx
@@ -1,8 +1,7 @@
-import { Add } from '@/assets/icons';
 import Button from '@/components/common/Button/Button';
 import CalendarList from '@/components/common/Calendar/CalendarList';
-import IconWrapper from '@/components/common/IconWrapper';
 import SquadDetailMemberList from '@/components/common/Member/SquadDetailMemberList';
+import TodoForm from '@/components/common/Todo/TodoForm';
 import TodoList from '@/components/common/Todo/TodoList';
 import { TODO_STATUS } from '@/constants/todo';
 import { squadDetailQueryOptions } from '@/hooks/queries/useSquad';
@@ -88,17 +87,7 @@ const SquadDetailPage = () => {
         <Button text="저장" variant="confirm" css={[saveButtonStyle(isTodoChanged)]} />
       </div>
       <TodoList todos={todos.data} />
-      <form css={formStyle}>
-        <input type="text" />
-        <IconWrapper
-          css={addIconStyle}
-          onClick={() => {
-            // TODO: 투두 등록 API 연동
-          }}
-        >
-          <Add />
-        </IconWrapper>
-      </form>
+      <TodoForm squadId={squadId} selectedDay={selectedDay} />
     </div>
   );
 };

--- a/src/Pages/SquadDetailPage.tsx
+++ b/src/Pages/SquadDetailPage.tsx
@@ -41,8 +41,7 @@ const SquadDetailPage = () => {
     ],
   });
 
-  // TODO: 수정 API와 함께 개선 필요
-  const isTodoChanged = useTodoStore((state) => state.isTodoChanged);
+  const { isTodoChanged, setIsTodoChanged } = useTodoStore((state) => state);
   const [progressRate, setProgressRate] = useState(0);
   const todoCount = todos.data.length;
 
@@ -87,7 +86,7 @@ const SquadDetailPage = () => {
         <Button text="저장" variant="confirm" css={[saveButtonStyle(isTodoChanged)]} />
       </div>
       <TodoList todos={todos.data} />
-      <TodoForm squadId={squadId} selectedDay={selectedDay} />
+      <TodoForm squadId={squadId} selectedDay={selectedDay} onChangeTodo={setIsTodoChanged} />
     </div>
   );
 };

--- a/src/apis/todo.ts
+++ b/src/apis/todo.ts
@@ -1,10 +1,20 @@
 import { instance } from '@/apis';
-import { GetTodoRequest, ToDoDetail } from '@/types';
+import { CreateTodoParamType } from '@/hooks/mutations';
+import { ApiResponse, GetTodoRequest, ToDoDetail } from '@/types';
+import { MutationFunction } from '@tanstack/react-query';
 
 export const getTodoList = async (params: GetTodoRequest): Promise<{ data: ToDoDetail[] }> => {
   const { squadId, memberId, queryParams } = params;
   const response = await instance.get(`/api/todos/squads/${squadId}/members/${memberId}`, {
     params: queryParams,
   });
+  return response.data;
+};
+
+export const createTodo: MutationFunction<ApiResponse<{ toDoId: number }>, CreateTodoParamType> = async ({
+  squadId,
+  newTodo,
+}) => {
+  const response = await instance.post(`/api/todos/squads/${squadId}`, newTodo);
   return response.data;
 };

--- a/src/components/common/Calendar/CalendarList.tsx
+++ b/src/components/common/Calendar/CalendarList.tsx
@@ -4,7 +4,7 @@ import { getDaysInMonth } from '@/utils/getDaysInMonth';
 import { css, Theme, useTheme } from '@emotion/react';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
-import { forwardRef, MouseEvent, useEffect, useMemo, useRef } from 'react';
+import { forwardRef, memo, MouseEvent, useEffect, useMemo, useRef } from 'react';
 
 type Props = {
   selectedDay: string;
@@ -52,14 +52,13 @@ const CalendarList = ({ selectedDay, onSelectDay, currentMonth }: Props) => {
   );
 };
 
-export default CalendarList;
+export default memo(CalendarList);
 
 const CalendarItem = forwardRef<HTMLLIElement, { day: string }>(({ day }, ref) => {
   const theme = useTheme();
   const selectedDay = useDayStore((state) => state.selectedDay);
   const isSelected = selectedDay === day;
   const isToday = format(new Date(), 'yyyy-MM-dd') === day;
-
   return (
     <li
       key={day}

--- a/src/components/common/Todo/TodoForm.tsx
+++ b/src/components/common/Todo/TodoForm.tsx
@@ -1,0 +1,96 @@
+import { Add } from '@/assets/icons';
+import IconWrapper from '@/components/common/IconWrapper';
+import { TODO_TYPES } from '@/constants/todo';
+import { useCreateTodo } from '@/hooks/mutations';
+import { todoKeys } from '@/hooks/queries/useTodo';
+import { useToastStore } from '@/stores/toast';
+import { PostTodoRequest } from '@/types';
+import { css, Theme } from '@emotion/react';
+import { useQueryClient } from '@tanstack/react-query';
+import { ChangeEvent, FormEvent, KeyboardEventHandler, useCallback, useState } from 'react';
+
+const TodoForm = ({ squadId, selectedDay }: { squadId: number; selectedDay: string }) => {
+  const [contents, setContents] = useState('');
+  const createToast = useToastStore((state) => state.createToast);
+  const queryClient = useQueryClient();
+  const { createTodoMutate } = useCreateTodo({
+    onSuccess: async () => {
+      createToast({ type: 'success', message: '투두가 등록되었어요 ✅', duration: 2000, showCloseButton: false });
+      queryClient.refetchQueries({
+        queryKey: todoKeys.todos(squadId),
+      });
+    },
+    onError: () => createToast({ type: 'failed', message: '투두 등록에 실패했어요 😢' }),
+  });
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const newTodo: PostTodoRequest = {
+      toDoType: TODO_TYPES.DAILY,
+      contents,
+      todoAt: selectedDay,
+    };
+    createTodoMutate({ squadId, newTodo });
+    setContents('');
+  };
+
+  const handleEnterSubmit: KeyboardEventHandler<HTMLFormElement> = useCallback((e) => {
+    if (e.key !== 'Enter') return;
+    if (!e.nativeEvent.isComposing) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  }, []);
+
+  return (
+    <form css={formStyle} onSubmit={handleSubmit}>
+      <input
+        type="text"
+        value={contents}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => setContents(e.target.value)}
+        autoFocus
+      />
+      <IconWrapper
+        css={addIconStyle}
+        onClick={() => {
+          // Button 태그로 인식하기 위한 로직
+        }}
+        onKeyDown={handleEnterSubmit}
+      >
+        <Add />
+      </IconWrapper>
+    </form>
+  );
+};
+
+export default TodoForm;
+
+const formStyle = (theme: Theme) => css`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: ${theme.colors.background.gray};
+  border-radius: 12px;
+  margin: 16px;
+
+  & input {
+    height: 40px;
+    flex: 1;
+    padding-left: 16px;
+    color: ${theme.colors.text};
+  }
+`;
+
+const addIconStyle = (theme: Theme) => css`
+  width: 32px;
+  height: 32px;
+  background-color: ${theme.colors.secondary};
+  border-radius: 50%;
+  margin-right: 8px;
+
+  & svg {
+    color: white;
+    width: 24px;
+    height: 24px;
+  }
+`;

--- a/src/components/common/Todo/TodoForm.tsx
+++ b/src/components/common/Todo/TodoForm.tsx
@@ -25,6 +25,13 @@ const TodoForm = ({ squadId, selectedDay }: { squadId: number; selectedDay: stri
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (!contents.length) {
+      createToast({
+        type: 'warning',
+        message: '할일을 입력해주세요',
+      });
+      return;
+    }
     const newTodo: PostTodoRequest = {
       toDoType: TODO_TYPES.DAILY,
       contents,

--- a/src/components/common/Todo/TodoForm.tsx
+++ b/src/components/common/Todo/TodoForm.tsx
@@ -9,13 +9,22 @@ import { css, Theme } from '@emotion/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { ChangeEvent, FormEvent, KeyboardEventHandler, useCallback, useState } from 'react';
 
-const TodoForm = ({ squadId, selectedDay }: { squadId: number; selectedDay: string }) => {
+const TodoForm = ({
+  squadId,
+  selectedDay,
+  onChangeTodo,
+}: {
+  squadId: number;
+  selectedDay: string;
+  onChangeTodo: (changed: boolean) => void;
+}) => {
   const [contents, setContents] = useState('');
   const createToast = useToastStore((state) => state.createToast);
   const queryClient = useQueryClient();
   const { createTodoMutate } = useCreateTodo({
     onSuccess: async () => {
       createToast({ type: 'success', message: '투두가 등록되었어요 ✅', duration: 2000, showCloseButton: false });
+      onChangeTodo(true);
       queryClient.refetchQueries({
         queryKey: todoKeys.todos(squadId),
       });

--- a/src/constants/todo.ts
+++ b/src/constants/todo.ts
@@ -2,3 +2,9 @@ export const TODO_STATUS = {
   PENDING: 'PENDING',
   COMPLETED: 'COMPLETED',
 };
+
+export const TODO_TYPES = {
+  DAILY: 'DAILY',
+  WEEKLY: 'WEEKLY',
+  MONTHLY: 'MONTHLY',
+} as const;

--- a/src/hooks/mutations/index.ts
+++ b/src/hooks/mutations/index.ts
@@ -1,6 +1,7 @@
 export * from './types';
 
 export { default as useCreateSquad } from './useCreateSquad';
+export { default as useCreateTodo } from './useCreateTodo';
 export { default as useDeleteSquad } from './useDeleteSquad';
 export { default as useExitSquad } from './useExitSquad';
 export { default as useRemoveUserFromSquad } from './useRemoveUserFromSquad';

--- a/src/hooks/mutations/types.ts
+++ b/src/hooks/mutations/types.ts
@@ -1,3 +1,4 @@
+import { PostTodoRequest } from '@/types';
 import { UseMutationOptions } from '@tanstack/react-query';
 
 /**
@@ -9,3 +10,8 @@ export type UpdateSquadNameParamType = { squadId: number; squadName: string };
 export type ExitAndDeleteSquadNameParamType = { squadId: number };
 export type AssignSquadLeaderParamType = { squadId: number; memberId: number };
 export type RemoveUserFromSquadParamType = { squadId: number; memberId: number };
+
+/**
+ * Todo
+ */
+export type CreateTodoParamType = { squadId: number; newTodo: PostTodoRequest };

--- a/src/hooks/mutations/useCreateTodo.tsx
+++ b/src/hooks/mutations/useCreateTodo.tsx
@@ -1,0 +1,14 @@
+import { createTodo } from '@/apis';
+import { CreateTodoParamType, MutateOptionsType } from '@/hooks/mutations/types';
+import { ApiResponse } from '@/types';
+import { useMutation } from '@tanstack/react-query';
+
+const useCreateTodo = (options: MutateOptionsType<ApiResponse<{ toDoId: number }>, CreateTodoParamType>) => {
+  const { mutate: createTodoMutate } = useMutation({
+    mutationFn: createTodo,
+    ...options,
+  });
+  return { createTodoMutate };
+};
+
+export default useCreateTodo;

--- a/src/hooks/queries/useSquad.tsx
+++ b/src/hooks/queries/useSquad.tsx
@@ -3,7 +3,7 @@ import { queryOptions } from '@tanstack/react-query';
 
 export const squadKeys = {
   squad: ['squadList'] as const,
-  squadDetail: (squadId: number) => [squadKeys.squad, squadId] as const,
+  squadDetail: (squadId: number) => [...squadKeys.squad, squadId] as const,
 };
 
 export const squadQueryOptions = () =>

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -1,4 +1,4 @@
-import { TODO_STATUS } from '@/constants/todo';
+import { TODO_STATUS, TODO_TYPES } from '@/constants/todo';
 
 export type ToDo = {
   toDoAt: string;
@@ -25,4 +25,12 @@ export type GetTodoRequest = {
     lastToDoId: number;
     pageSize: number;
   };
+};
+
+export type TodoTypes = (typeof TODO_TYPES)[keyof typeof TODO_TYPES];
+
+export type PostTodoRequest = {
+  toDoType: TodoTypes;
+  contents: string;
+  todoAt: string;
 };


### PR DESCRIPTION
## 작업 사항
- 투두 등록 API 함수 작성
- TodoForm 컴포넌트 분리
  - Enter로 등록 가능하도록 구현
- 투두 등록 시 저장 버튼 활성화
  - 수정 및 삭제 기능 구현과 함께 로직 개선 필요 예상

## 변경 사항
- `CalendarList` 컴포넌트에 `React.memo` 적용

### 추가 정보
- 등록 및 수정 시 리렌더링으로 성능이 좋지 않으면 개선이 필요할 수 있음 (협의)

## 관련 이슈
close #67 