### PR TITLE
Fix: 스쿼드 나가기에 리더 확인 로직 추가

### DIFF
--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -22,6 +22,7 @@ const Sidebar = ({ closeSidebar }: { closeSidebar: VoidFunction }) => {
     refetchOnMount: false,
   }).data;
   const { squadName, squadMembers, mySquadMemberRole } = squadDetail;
+  const isLeader = mySquadMemberRole === ROLE.LEADER;
 
   const queryClient = useQueryClient();
   const { UpdateSquadNameModal, handleUpdateSquadName } = useUpdateSquadName(squadId, {
@@ -43,7 +44,7 @@ const Sidebar = ({ closeSidebar }: { closeSidebar: VoidFunction }) => {
   });
 
   const hasMembers = squadMembers.length > 1;
-  const { ExitSquadModal, handleSquadExit } = useExitSquad(squadId, hasMembers, {
+  const { ExitSquadModal, handleSquadExit } = useExitSquad(squadId, isLeader, hasMembers, {
     onSuccess: () => {
       createToast({ type: 'success', message: '스쿼드에서 나왔어요' });
       navigate('/squads');
@@ -77,7 +78,7 @@ const Sidebar = ({ closeSidebar }: { closeSidebar: VoidFunction }) => {
               onClick={handleUpdateSquadName}
               role="button"
               css={commonButtonStyle}
-              disabled={mySquadMemberRole !== ROLE.LEADER}
+              disabled={!isLeader}
             >
               <Edit />
             </IconWrapper>
@@ -98,7 +99,7 @@ const Sidebar = ({ closeSidebar }: { closeSidebar: VoidFunction }) => {
             >
               멤버 초대
             </li>
-            {mySquadMemberRole === ROLE.LEADER && (
+            {isLeader && (
               <li
                 onClick={() => {
                   closeSidebar();
@@ -112,7 +113,7 @@ const Sidebar = ({ closeSidebar }: { closeSidebar: VoidFunction }) => {
                 리더 변경
               </li>
             )}
-            {mySquadMemberRole === ROLE.LEADER && <li onClick={handleSquadDelete}>스쿼드 삭제</li>}
+            {isLeader && <li onClick={handleSquadDelete}>스쿼드 삭제</li>}
           </ul>
         </section>
         <button css={exitButtonStyle} onClick={handleSquadExit}>

--- a/src/hooks/mutations/useExitSquad.tsx
+++ b/src/hooks/mutations/useExitSquad.tsx
@@ -8,6 +8,7 @@ import { useMutation } from '@tanstack/react-query';
 
 const useExitSquad = (
   squadId: number,
+  isLeader: boolean,
   hasMembers: boolean,
   options: MutateOptionsType<ApiResponse<null>, ExitAndDeleteSquadNameParamType>,
 ) => {
@@ -32,7 +33,7 @@ const useExitSquad = (
       displayCancel: true,
     } as const;
 
-    const res = await openModal(ActionPrompt, undefined, hasMembers ? checkInfo : exitInfo);
+    const res = await openModal(ActionPrompt, undefined, hasMembers && isLeader ? checkInfo : exitInfo);
     if (res.ok && !hasMembers) {
       exitSquadMutate({ squadId });
     }

--- a/src/types/squad.ts
+++ b/src/types/squad.ts
@@ -1,5 +1,7 @@
 import { ROLE } from '@/constants/role';
 
+export type squadRoleType = (typeof ROLE)[keyof typeof ROLE];
+
 export type Squad = {
   squadId: number;
   squadName: string;
@@ -7,12 +9,12 @@ export type Squad = {
 
 export type SquadDetail = {
   squadMembers: SquadMember[];
-  mySquadMemberRole: (typeof ROLE)[keyof typeof ROLE];
+  mySquadMemberRole: squadRoleType;
 } & Squad;
 
 export type SquadMember = {
   memberId: number;
   profileImg: string | null;
   name: string;
-  squadMemberRole: (typeof ROLE)[keyof typeof ROLE];
+  squadMemberRole: squadRoleType;
 };


### PR DESCRIPTION
## 작업 사항
- 리더가 아닌 멤버는 `exitInfo`, 리더이면서 멤버도 2명 이상일 경우 `checkInfo` 렌더링

## 변경 사항
- 리더 여부를 `isLeader` 변수로 관리

## 관련 이슈
close #78 