### PR TITLE
Feat: 스쿼드 내 멤버의 투두리스트 조회 기능 구현

### DIFF
--- a/src/apis/todo.ts
+++ b/src/apis/todo.ts
@@ -4,9 +4,9 @@ import { ApiResponse, CreateAndUpdateResponseType, GetTodoRequestParams, ToDoDet
 import { MutationFunction } from '@tanstack/react-query';
 
 export const getTodoList = async (params: GetTodoRequestParams): Promise<{ data: ToDoDetail[] }> => {
-  const { squadId, memberId, queryParams } = params;
+  const { squadId, memberId, payload } = params;
   const response = await instance.get(`/api/todos/squads/${squadId}/members/${memberId}`, {
-    params: queryParams,
+    params: payload,
   });
   return response.data;
 };

--- a/src/components/common/Member/MemberTodoItem.tsx
+++ b/src/components/common/Member/MemberTodoItem.tsx
@@ -1,0 +1,39 @@
+import { Check } from '@/assets/icons';
+import IconWrapper from '@/components/common/IconWrapper';
+import {
+  checkedStyle,
+  checkIconStyle,
+  contentStyle,
+  getStatusStyles,
+  todoItemStyle,
+} from '@/components/common/Todo/TodoList';
+import { TODO_STATUS } from '@/constants/todo';
+import { ToDoDetail } from '@/types';
+import { css, useTheme } from '@emotion/react';
+
+const MemberTodoItem = ({ todo }: { todo: ToDoDetail }) => {
+  const isCompleted = todo.toDoStatus === TODO_STATUS.COMPLETED;
+  const theme = useTheme();
+  return (
+    <li css={[todoItemStyle(), getStatusStyles(isCompleted, theme), memberTodoItemStyle]}>
+      <div css={contentStyle}>
+        <IconWrapper
+          aria-label={isCompleted ? 'Completed todo' : 'Uncompleted todo'}
+          aria-checked={isCompleted}
+          role="checkbox"
+          css={[checkIconStyle, isCompleted && checkedStyle]}
+        >
+          {isCompleted && <Check />}
+        </IconWrapper>
+        <p>{todo.contents}</p>
+      </div>
+    </li>
+  );
+};
+
+export default MemberTodoItem;
+
+const memberTodoItemStyle = css`
+  cursor: default;
+  opacity: 0.5;
+`;

--- a/src/components/common/Member/SquadDetailMemberList.tsx
+++ b/src/components/common/Member/SquadDetailMemberList.tsx
@@ -1,4 +1,5 @@
 import MemberProfile from '@/components/common/Member/MemberProfile';
+import { useMemberStore } from '@/stores/member';
 import { scrollBarStyle } from '@/styles/globalStyles';
 import { SquadMember } from '@/types';
 import { css, Theme } from '@emotion/react';
@@ -20,8 +21,9 @@ const SquadDetailMemberList = ({ squadMembers }: Props) => {
 export default SquadDetailMemberList;
 
 const Member = ({ member }: { member: SquadMember }) => {
+  const setSelectedMember = useMemberStore((state) => state.setSelectedMember);
   return (
-    <li>
+    <li onClick={() => setSelectedMember(member)} css={memberStyle}>
       <MemberProfile member={member} infoStyle={infoStyle} imgStyle={imgStyle} displayRole={false} />
     </li>
   );
@@ -35,6 +37,10 @@ const containerStyle = css`
   margin: 0 16px;
   overflow-x: auto;
   ${scrollBarStyle}
+`;
+
+const memberStyle = css`
+  cursor: pointer;
 `;
 
 const imgStyle = css`

--- a/src/components/common/Member/index.ts
+++ b/src/components/common/Member/index.ts
@@ -1,2 +1,3 @@
 export { default as MemberProfile } from './MemberProfile';
+export { default as MemberTodoItem } from './MemberTodoItem';
 export { default as SidebarMemberList } from './SidebarMemberList';

--- a/src/components/common/Todo/TodoList.tsx
+++ b/src/components/common/Todo/TodoList.tsx
@@ -1,6 +1,7 @@
 import { Check, Close, Delete, Edit } from '@/assets/icons';
 import Button from '@/components/common/Button/Button';
 import IconWrapper from '@/components/common/IconWrapper';
+import { MemberTodoItem } from '@/components/common/Member';
 import { TODO_STATUS } from '@/constants/todo';
 import { useDeleteTodo, useUpdateTodo } from '@/hooks/mutations';
 import { InfiniteQueryData } from '@/hooks/queries/types';
@@ -16,9 +17,10 @@ import { KeyboardEvent, MouseEvent, useEffect, useRef, useState } from 'react';
 type Props = {
   todos: ToDoDetail[];
   loadMoreTodos: VoidFunction;
+  isMeSelected: boolean;
 };
 
-const TodoList = ({ todos, loadMoreTodos }: Props) => {
+const TodoList = ({ todos, loadMoreTodos, isMeSelected }: Props) => {
   const loadMoreRef = useRef(null);
 
   useEffect(() => {
@@ -48,10 +50,10 @@ const TodoList = ({ todos, loadMoreTodos }: Props) => {
   }, [loadMoreTodos]);
 
   return (
-    <ul css={todoContainerStyle}>
-      {todos.map((todo) => (
-        <TodoItem key={todo.toDoId} todo={todo} />
-      ))}
+    <ul css={[todoContainerStyle, !isMeSelected && memberTodoListStyle]}>
+      {todos.map((todo) =>
+        isMeSelected ? <TodoItem key={todo.toDoId} todo={todo} /> : <MemberTodoItem key={todo.toDoId} todo={todo} />,
+      )}
       <br />
       <div ref={loadMoreRef} />
     </ul>
@@ -215,6 +217,10 @@ export const todoContainerStyle = (theme: Theme) => css`
   overflow-y: auto;
   -webkit-box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.1);
   box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.1);
+`;
+
+const memberTodoListStyle = css`
+  margin-bottom: 24px;
 `;
 
 const slideInFromRight = keyframes`

--- a/src/hooks/queries/useTodo.tsx
+++ b/src/hooks/queries/useTodo.tsx
@@ -1,18 +1,12 @@
 import { getTodoList } from '@/apis';
-import { GetTodoRequestParams, GetTodoRequestPayload } from '@/types';
-import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query';
+import { GetTodoRequestPayload } from '@/types';
+import { infiniteQueryOptions } from '@tanstack/react-query';
 
 export const todoKeys = {
   todos: (squadId: number, day: string) => ['todoList', squadId, day] as const,
   todoById: (squadId: number, day: string, todoId: number) => [...todoKeys.todos(squadId, day), todoId] as const,
   todosByMember: (squadId: number, day: string, memberId: number) => [...todoKeys.todos(squadId, day), memberId],
 };
-
-export const todoQueryOptions = (selectedDay: string, params: GetTodoRequestParams) =>
-  queryOptions({
-    queryKey: todoKeys.todos(params.squadId, selectedDay),
-    queryFn: () => getTodoList(params),
-  });
 
 export const todoInfiniteQueryOptions = (
   memberId: number,
@@ -26,7 +20,7 @@ export const todoInfiniteQueryOptions = (
       getTodoList({
         squadId,
         memberId,
-        queryParams: {
+        payload: {
           ...queryParams,
           lastToDoId: pageParam,
         },

--- a/src/stores/member.ts
+++ b/src/stores/member.ts
@@ -1,0 +1,12 @@
+import { SquadMember } from '@/types';
+import { create } from 'zustand';
+
+type MemberState = {
+  selectedMember: SquadMember | null;
+  setSelectedMember: (member: SquadMember | null) => void;
+};
+
+export const useMemberStore = create<MemberState>((set) => ({
+  selectedMember: null,
+  setSelectedMember: (member) => set({ selectedMember: member }),
+}));

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -18,7 +18,7 @@ export type TodoStatus = (typeof TODO_STATUS)[keyof typeof TODO_STATUS];
 export type GetTodoRequestParams = {
   squadId: number;
   memberId: number;
-  queryParams: GetTodoRequestPayload;
+  payload: GetTodoRequestPayload;
 };
 
 export type GetTodoRequestPayload = {


### PR DESCRIPTION
## 작업 사항
- 기존 `TodoList` 컴포넌트를 이용해 멤버의 투두리스트 렌더링
   - 수정 및 삭제 기능을 제외시키기 위한 `MemberTodoItem` 컴포넌트 추가
- 선택된(조회중인) 멤버 관리를 위한 store 추가
- 멤버의 투두리스트 조회도 기존 `useInfiniteQuery` 로직 재사용

## 변경 사항
- POST 요청 시 Request Body 데이터 타입명을 명확히 수정

## 관련 이슈
close #82 #83 