### PR TITLE
Feat: 스쿼드 멤버 초대 mockAPI 연동

### DIFF
--- a/src/Pages/InvitePage.tsx
+++ b/src/Pages/InvitePage.tsx
@@ -4,17 +4,26 @@ import Button from '@/components/common/Button/Button';
 import Form from '@/components/common/Form';
 import IconWrapper from '@/components/common/IconWrapper';
 import { checkedStyle, checkIconStyle } from '@/components/common/Todo/TodoList';
+import useInviteMember from '@/hooks/mutations/useInviteMember';
 import useToastHandler from '@/hooks/useToastHandler';
+import { useSquadStore } from '@/stores';
 import { SearchMemberResponse } from '@/types';
 import { css, Theme, useTheme } from '@emotion/react';
 import { FormEvent, KeyboardEventHandler, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const InvitePage = () => {
+  const squadId = useSquadStore((state) => state.currentSquadId);
   const [searchKeyword, setSearchKeyword] = useState('');
   const [searchResult, setSearchResult] = useState<SearchMemberResponse | null>(null);
   const [isSelected, setIsSelected] = useState(false);
+  const { successToast, warningToast, failedToast } = useToastHandler();
   const theme = useTheme();
-  const { warningToast, failedToast } = useToastHandler();
+  const navigate = useNavigate();
+  const { searchMemberMutate } = useInviteMember({
+    onSuccess: (data) => successToast('멤버 초대에 성공했어요.'),
+    onError: () => failedToast('멤버 초대에 실패했어요.'),
+  });
 
   const handleSearch = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -38,6 +47,16 @@ const InvitePage = () => {
       handleSearch(e);
     }
   };
+
+  const handleInvite = () => {
+    if (!searchResult) {
+      warningToast('초대할 멤버를 확인해주세요.');
+      return;
+    }
+    searchMemberMutate({ squadId, memberId: searchResult.memberId });
+    navigate(-1);
+  };
+
   return (
     <section css={containerStyle}>
       <Form
@@ -64,9 +83,7 @@ const InvitePage = () => {
       )}
       <Button
         text="초대하기"
-        onClick={() => {
-          console.log('초대할게유');
-        }}
+        onClick={handleInvite}
         style={{
           marginTop: 'auto',
           height: '56px',

--- a/src/apis/mockApi.ts
+++ b/src/apis/mockApi.ts
@@ -1,6 +1,7 @@
 import {
   CreateSquadParamType,
   CreateTodoParamType,
+  InviteMemberParamType,
   UpdateSquadNameParamType,
   UpdateTodoParamType,
 } from '@/hooks/mutations';
@@ -51,5 +52,16 @@ export const createTodoApi: MutationFunction<ApiResponse<{ toDoId: number }>, Cr
 
 export const updateTodoApi: MutationFunction<ApiResponse<null>, UpdateTodoParamType> = async ({ toDoId, newTodo }) => {
   const response = await mockInstance.put(`/api/todos/${toDoId}`, newTodo);
+  return response.data;
+};
+
+export const inviteMemberApi: MutationFunction<ApiResponse<null>, InviteMemberParamType> = async ({
+  squadId,
+  memberId,
+}) => {
+  const response = await mockInstance.post(`/api/squads/${squadId}/members/${memberId}`, {
+    squadId,
+    memberId,
+  });
   return response.data;
 };

--- a/src/hooks/mutations/types.ts
+++ b/src/hooks/mutations/types.ts
@@ -17,3 +17,8 @@ export type RemoveUserFromSquadParamType = { squadId: number; memberId: number }
 export type CreateTodoParamType = { squadId: number; newTodo: PostTodoRequest };
 export type UpdateTodoParamType = { toDoId: number; newTodo: UpdateTodoRequest };
 export type DeleteTodoParamType = { toDoId: number; squadId: number };
+
+/**
+ * Invite
+ */
+export type InviteMemberParamType = { squadId: number; memberId: number };

--- a/src/hooks/mutations/useInviteMember.tsx
+++ b/src/hooks/mutations/useInviteMember.tsx
@@ -1,0 +1,14 @@
+import { inviteMemberApi } from '@/apis/mockApi';
+import { InviteMemberParamType, MutateOptionsType } from '@/hooks/mutations/types';
+import { ApiResponse } from '@/types';
+import { useMutation } from '@tanstack/react-query';
+
+const useInviteMember = (options: MutateOptionsType<ApiResponse<null>, InviteMemberParamType>) => {
+  const { mutate: searchMemberMutate } = useMutation({
+    mutationFn: inviteMemberApi,
+    ...options,
+  });
+  return { searchMemberMutate };
+};
+
+export default useInviteMember;

--- a/src/mocks/handler/squadHandler.ts
+++ b/src/mocks/handler/squadHandler.ts
@@ -1,3 +1,4 @@
+import { InviteMemberParamType } from '@/hooks/mutations';
 import { ApiResponse, Squad, SquadDetail } from '@/types';
 import { http, HttpResponse } from 'msw';
 
@@ -68,11 +69,20 @@ export const squadHandler = [
       {
         status: 200,
       },
-      // {
-      //   statusCodeValue: 401,
-      //   message: '허용할 수 없는 접근입니다.',
-      //   data: null,
-      // },
     );
   }),
+
+  http.post(`${import.meta.env.VITE_MOCK_API_URL}/api/squads/2/members/2`, async () =>
+    HttpResponse.json<ApiResponse<InviteMemberParamType>>(
+      {
+        data: {
+          squadId: 2,
+          memberId: 2,
+        },
+        message: 'POST 요청 성공!',
+        statusCodeValue: 0,
+      },
+      { status: 201 },
+    ),
+  ),
 ];


### PR DESCRIPTION
## 작업 사항
- 멤버 초대 mockAPI 추가
- mutate 훅 작성
- `InvitePage` 멤버 초대 API 연동

### 추가 정보
- 알림창 및 수락 기능 구현 시 실제 API로 대체 예정

## 관련 이슈
close #86 
