### PR TITLE
Feat: 알림 읽음 여부 변경 API 연동

### DIFF
--- a/src/apis/notification.ts
+++ b/src/apis/notification.ts
@@ -1,4 +1,5 @@
 import { instance } from '@/apis';
+import { ApiResponse } from '@/types';
 import { NotificationRequestPayload, NotificationResponse } from '@/types/notification';
 
 export const getNotifications = async (
@@ -7,5 +8,14 @@ export const getNotifications = async (
   const response = await instance.get(`/api/notifications/me`, {
     params,
   });
+  return response.data;
+};
+
+export const readNotification = async ({
+  notificationId,
+}: {
+  notificationId: number;
+}): Promise<ApiResponse<NotificationResponse>> => {
+  const response = await instance.put(`/api/notifications/${notificationId}`);
   return response.data;
 };

--- a/src/components/common/Notification.tsx
+++ b/src/components/common/Notification.tsx
@@ -5,6 +5,7 @@ import { Overlay } from '@/components/common/Overlay';
 import { commonButtonStyle, headerStyle, sidebarContainer } from '@/components/common/Sidebar';
 import { INVITATION_TYPE } from '@/constants/squad';
 import useAcceptInvitation from '@/hooks/mutations/useAcceptInvitation';
+import { useReadNotification } from '@/hooks/mutations/useReadNotification';
 import notificationInfiniteQueryOptions from '@/hooks/queries/useNotification';
 import { squadKeys } from '@/hooks/queries/useSquad';
 import useInfinite from '@/hooks/useInfinite';
@@ -77,7 +78,7 @@ Notification.List = ({
 
 Notification.Item = ({ data }: { data: NotificationResponse }) => {
   const [isAccept, setIsAccept] = useState(false);
-  const { notificationType, notificationData, read } = data;
+  const { notificationType, notificationData, read, notificationId } = data;
   const { failedToast } = useToastHandler();
   const { acceptInvitation } = useAcceptInvitation({
     onSuccess: () => {
@@ -91,6 +92,7 @@ Notification.Item = ({ data }: { data: NotificationResponse }) => {
       setIsAccept(false);
     },
   });
+  const { readNotificationMutate } = useReadNotification();
 
   const message =
     notificationType === INVITATION_TYPE.INVITE_REQUEST
@@ -98,8 +100,8 @@ Notification.Item = ({ data }: { data: NotificationResponse }) => {
       : `${notificationData.userName}님을 ${notificationData.squadName}스쿼드에 초대했어요`;
 
   const handleReadStatus = (e: MouseEvent<HTMLLIElement>) => {
-    // TODO: 읽음 처리 PUT 요청
     if (read) return;
+    readNotificationMutate({ notificationId });
   };
 
   const handleAccept = (e: MouseEvent<HTMLButtonElement>) => {

--- a/src/hooks/mutations/useReadNotification.tsx
+++ b/src/hooks/mutations/useReadNotification.tsx
@@ -1,0 +1,53 @@
+import { readNotification } from '@/apis/notification';
+import { MutateOptionsType } from '@/hooks/mutations/types';
+import { InfiniteQueryData } from '@/hooks/queries/types';
+import { notiKeys } from '@/hooks/queries/useNotification';
+import { ApiResponse } from '@/types';
+import { NotificationResponse } from '@/types/notification';
+import { optimisticUpdateMutateHandler } from '@/utils/optimisticUpdateMutateHandler';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useReadNotification = (
+  options?: MutateOptionsType<
+    ApiResponse<NotificationResponse>,
+    { notificationId: number },
+    { oldData: InfiniteQueryData<ApiResponse<NotificationResponse[]>> | never[] | undefined }
+  >,
+) => {
+  const queryClient = useQueryClient();
+  const { mutate: readNotificationMutate } = useMutation({
+    mutationFn: readNotification,
+    onMutate: async (data) => {
+      const oldData = await optimisticUpdateMutateHandler<InfiniteQueryData<ApiResponse<NotificationResponse[]>>>(
+        queryClient,
+        notiKeys.all,
+        (prevData: InfiniteQueryData<ApiResponse<NotificationResponse[]>>) => {
+          const updatedPages = [...prevData.pages];
+          updatedPages.some((page, pageIndex) => {
+            const targetIndex = page.data.findIndex((v) => v.notificationId === data.notificationId);
+            if (targetIndex === -1) return false;
+
+            const updatedData = [...page.data];
+            updatedData[targetIndex] = {
+              ...updatedData[targetIndex],
+              read: true,
+            };
+            updatedPages[pageIndex] = { ...page, data: updatedData };
+            return true;
+          });
+
+          return { ...prevData, pages: updatedPages };
+        },
+      );
+      return { oldData };
+    },
+    onError: (error, variables, context) => {
+      if (context?.oldData) {
+        queryClient.setQueryData(notiKeys.all, context.oldData);
+      }
+    },
+    ...options,
+  });
+
+  return { readNotificationMutate };
+};


### PR DESCRIPTION
## 작업 사항
- API 함수 추가
- 읽음 여부에 낙관적 업데이트 구현
  - `optimisticUpdateMutateHandler` 유틸 함수 활용
  - 이중 `map` 개선 

## 관련 이슈
close #112 