### PR TITLE
Fix: 투두 생성/수정/삭제 낙관적 업데이트 오류 해결

### DIFF
--- a/src/Pages/SquadDetailPage.tsx
+++ b/src/Pages/SquadDetailPage.tsx
@@ -88,7 +88,7 @@ const SquadDetailPage = () => {
         <span>{!selectedMember ? user?.name : selectedMember.name}</span>
         <span>달성률: {progressRate}%</span>
       </div>
-      <TodoList todos={todos} loadMoreTodos={loadMoreTodos} isMeSelected={isMeSelected} />
+      <TodoList todos={todos} loadMoreTodos={loadMoreTodos} hasNextPage={hasNextPage} isMeSelected={isMeSelected} />
       {isMeSelected && <TodoForm squadId={squadId} selectedDay={selectedDay} />}
     </section>
   );

--- a/src/components/common/Todo/TodoForm.tsx
+++ b/src/components/common/Todo/TodoForm.tsx
@@ -13,7 +13,7 @@ const TodoForm = ({ squadId, selectedDay }: { squadId: number; selectedDay: stri
   const [contents, setContents] = useState('');
   const { successToast, failedToast, warningToast } = useToastHandler();
   const queryClient = useQueryClient();
-  const { createTodoMutate } = useCreateTodo(squadId, selectedDay, {
+  const { createTodoMutate } = useCreateTodo({
     onSuccess: async ({ data }) => {
       successToast('투두 등록에 성공했어요');
       queryClient.setQueryData(

--- a/src/components/common/Todo/TodoList.tsx
+++ b/src/components/common/Todo/TodoList.tsx
@@ -6,48 +6,24 @@ import { TODO_STATUS } from '@/constants/todo';
 import { useDeleteTodo, useUpdateTodo } from '@/hooks/mutations';
 import { InfiniteQueryData } from '@/hooks/queries/types';
 import { todoKeys } from '@/hooks/queries/useTodo';
+import useInfinite from '@/hooks/useInfinite';
 import useToastHandler from '@/hooks/useToastHandler';
 import { useDayStore, useSquadStore } from '@/stores';
 import { ApiResponse, ToDoDetail, UpdateTodoRequest } from '@/types';
 import handleKeyDown from '@/utils/handleKeyDown';
 import { css, keyframes, Theme, useTheme } from '@emotion/react';
 import { useQueryClient } from '@tanstack/react-query';
-import { KeyboardEvent, useEffect, useRef, useState } from 'react';
+import { KeyboardEvent, useState } from 'react';
 
 type Props = {
   todos: ToDoDetail[];
   loadMoreTodos: VoidFunction;
+  hasNextPage: boolean;
   isMeSelected: boolean;
 };
 
-export const TodoList = ({ todos, loadMoreTodos, isMeSelected }: Props) => {
-  const loadMoreRef = useRef(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting) {
-          try {
-            loadMoreTodos();
-          } catch (err) {
-            console.log(err);
-          }
-        }
-      },
-      { threshold: 1.0 },
-    );
-
-    // 타겟이 마운트되서 ref 객체에 참조 객체가 생기면
-    const ref = loadMoreRef.current;
-    if (ref) {
-      observer.observe(ref);
-    }
-    return () => {
-      if (ref) {
-        observer.unobserve(ref);
-      }
-    };
-  }, [loadMoreTodos]);
+export const TodoList = ({ todos, loadMoreTodos, hasNextPage, isMeSelected }: Props) => {
+  const { loadMoreRef } = useInfinite(loadMoreTodos, hasNextPage);
 
   return (
     <ul css={[todoContainerStyle, !isMeSelected && memberTodoListStyle]}>

--- a/src/components/common/Todo/TodoList.tsx
+++ b/src/components/common/Todo/TodoList.tsx
@@ -63,7 +63,7 @@ export const TodoList = ({ todos, loadMoreTodos, isMeSelected }: Props) => {
 const TodoItem = ({ todo }: { todo: ToDoDetail }) => {
   const squadId = useSquadStore((state) => state.currentSquadId);
   const theme = useTheme();
-  const { toDoAt, toDoId, contents, squadToDoId, toDoStatus } = todo;
+  const { toDoAt, toDoId, contents, toDoStatus } = todo;
   const [currentToDoStatus, setCurrentToDoStatus] = useState(todo.toDoStatus);
   const selectedDay = useDayStore((state) => state.selectedDay);
   const [isEditMode, setIsEditMode] = useState(false);
@@ -90,8 +90,8 @@ const TodoItem = ({ todo }: { todo: ToDoDetail }) => {
     },
     onError: (error, data, context) => {
       failedToast('수정에 실패했어요');
-      if (context) {
-        queryClient.setQueryData(todoKeys.todos(squadToDoId, selectedDay), context);
+      if (context?.oldData) {
+        queryClient.setQueryData(todoKeys.todos(squadId, selectedDay), context.oldData);
       }
     },
   });
@@ -100,8 +100,8 @@ const TodoItem = ({ todo }: { todo: ToDoDetail }) => {
     onSuccess: () => successToast('삭제에 성공했어요'),
     onError: (error, data, context) => {
       failedToast('삭제에 실패했어요');
-      if (context) {
-        queryClient.setQueryData(todoKeys.todos(squadToDoId, selectedDay), context);
+      if (context?.oldData) {
+        queryClient.setQueryData(todoKeys.todos(squadId, selectedDay), context.oldData);
       }
     },
   });

--- a/src/hooks/mutations/useCreateTodo.tsx
+++ b/src/hooks/mutations/useCreateTodo.tsx
@@ -1,19 +1,11 @@
 import { createTodo } from '@/apis';
 import { CreateTodoParamType, MutateOptionsType } from '@/hooks/mutations/types';
-import { todoKeys } from '@/hooks/queries/useTodo';
 import { ApiResponse, CreateAndUpdateResponseType } from '@/types';
-import { optimisticUpdateMutateHandler } from '@/utils/optimisticUpdateMutateHandler';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 
-const useCreateTodo = (
-  squadId: number,
-  selectedDay: string,
-  options: MutateOptionsType<ApiResponse<CreateAndUpdateResponseType>, CreateTodoParamType>,
-) => {
-  const queryClient = useQueryClient();
+const useCreateTodo = (options: MutateOptionsType<ApiResponse<CreateAndUpdateResponseType>, CreateTodoParamType>) => {
   const { mutate: createTodoMutate } = useMutation({
     mutationFn: createTodo,
-    onMutate: () => optimisticUpdateMutateHandler(queryClient, todoKeys.todos(squadId, selectedDay)),
     ...options,
   });
   return { createTodoMutate };

--- a/src/hooks/mutations/useUpdateTodo.tsx
+++ b/src/hooks/mutations/useUpdateTodo.tsx
@@ -9,16 +9,23 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 export const useUpdateTodo = (
   squadId: number,
   selectedDay: string,
-  options: MutateOptionsType<ApiResponse<CreateAndUpdateResponseType>, UpdateTodoParamType>,
+  options: MutateOptionsType<
+    ApiResponse<CreateAndUpdateResponseType>,
+    UpdateTodoParamType,
+    { oldData: InfiniteQueryData<ApiResponse<ToDoDetail[]>> | never[] | undefined }
+  >,
 ) => {
   const queryClient = useQueryClient();
   const { mutate: updateTodoMutate } = useMutation({
     mutationFn: updateTodo,
-    onMutate: () =>
-      optimisticUpdateMutateHandler<InfiniteQueryData<ApiResponse<ToDoDetail[]>>>(
+    onMutate: async () => {
+      const oldData = await optimisticUpdateMutateHandler<InfiniteQueryData<ApiResponse<ToDoDetail[]>>>(
         queryClient,
         todoKeys.todos(squadId, selectedDay),
-      ),
+      );
+
+      return { oldData };
+    },
     ...options,
   });
   return { updateTodoMutate };


### PR DESCRIPTION
## 작업 사항
- 투두 생성 시 불필요한 `onMutate` 로직 제거
- 수정/삭제 시 `optimisticUpdateMutateHandler` 비동기 함수의 반환값 수정
  - setQueryData의 `key`값 수정
- 투두리스트 무한스크롤 로직 `useInfinite` 훅으로 대체

### 추가 정보
- 기존에는 key값을 squadId가 아닌 toDoId를 사용했는데 key 형식과 맞지 않음
- 성능에 문제가 있으면 개선 필요

## 관련 이슈
close #124 