### PR TITLE
Fix: 특정 경로에서 squadId로 인한 새로고침 오류 문제

### DIFF
--- a/src/Router/router.tsx
+++ b/src/Router/router.tsx
@@ -2,6 +2,7 @@ import App from '@/App';
 import { MainLayout } from '@/components';
 import Loading from '@/components/common/Loading';
 import LoginLayout from '@/components/layouts/LoginLayout';
+import SquadIdGuard from '@/components/SquadIdGuard';
 import { HomePage, LoginPage, MyPage, SquadDetailPage, SquadPage } from '@/Pages';
 import GoogleOAuthCallbackPage from '@/Pages/GoogleOAuthLoginPage';
 import InvitePage from '@/Pages/InvitePage';
@@ -46,11 +47,19 @@ export const router = createBrowserRouter([
           },
           {
             path: '/squads/:squadId/members',
-            element: <SelectMemberPage />,
+            element: (
+              <SquadIdGuard>
+                <SelectMemberPage />
+              </SquadIdGuard>
+            ),
           },
           {
             path: '/squads/:squadId/invite',
-            element: <InvitePage />,
+            element: (
+              <SquadIdGuard>
+                <InvitePage />
+              </SquadIdGuard>
+            ),
           },
           {
             path: '/me',

--- a/src/components/SquadIdGuard.tsx
+++ b/src/components/SquadIdGuard.tsx
@@ -1,0 +1,16 @@
+import { useSquadStore } from '@/stores';
+import { PropsWithChildren } from 'react';
+import { Navigate, useParams } from 'react-router-dom';
+
+const SquadIdGuard = ({ children }: PropsWithChildren) => {
+  const { squadId } = useParams();
+  const currentSquadId = useSquadStore((state) => state.currentSquadId);
+
+  if (!currentSquadId || currentSquadId.toString() !== squadId) {
+    return <Navigate to={`/squads/${squadId}`} replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default SquadIdGuard;

--- a/src/stores/squad.ts
+++ b/src/stores/squad.ts
@@ -8,8 +8,7 @@ type SquadState = {
 export const useSquadStore = create<SquadState>((set) => ({
   currentSquadId: 0,
   setCurrentSquadId: (squadId) =>
-    set((state) => ({
-      ...state,
+    set({
       currentSquadId: squadId,
-    })),
+    }),
 }));


### PR DESCRIPTION
## 원인
- 멤버 초대/리더 변경 페이지에서 새로고침 시 전역 상태로 관리 되는 squadId가 null로 초기화 되어 발생

## 작업 사항
- `SquadIdGuard` 경로 보호 컴포넌트를 라우트 레벨에서 사용
   - 새록고침 시 squadId를 확인하고 없으면 상세 페이지로 돌아가도록 함

## 관련 이슈
close #130 