### PR TITLE
Refactor: 투두 수정 낙관적 업데이트 로직 onMutate에서 처리하도록 개선

### DIFF
--- a/src/components/Todo/TodoList.tsx
+++ b/src/components/Todo/TodoList.tsx
@@ -6,9 +6,8 @@ import { TODO_STATUS } from '@/constants/todo';
 import { useInfinite, useToastHandler } from '@/hooks';
 import { useDeleteTodo, useUpdateTodo } from '@/hooks/mutations';
 import { todoKeys } from '@/hooks/queries';
-import { InfiniteQueryData } from '@/hooks/queries/types';
 import { useDayStore, useSquadStore } from '@/stores';
-import { ApiResponse, ToDoDetail, UpdateTodoRequest } from '@/types';
+import { ToDoDetail, UpdateTodoRequest } from '@/types';
 import { handleKeyDown } from '@/utils';
 import { css, keyframes, Theme, useTheme } from '@emotion/react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -49,20 +48,8 @@ const TodoItem = ({ todo }: { todo: ToDoDetail }) => {
 
   const queryClient = useQueryClient();
   // TODO 상태 및 내용 수정 로직 공유
-  const { updateTodoMutate } = useUpdateTodo(squadId, selectedDay, {
-    onSuccess: ({ data }) => {
-      successToast('수정에 성공했어요');
-      queryClient.setQueryData(
-        todoKeys.todos(squadId, selectedDay),
-        (prevData: InfiniteQueryData<ApiResponse<ToDoDetail[]>>) => ({
-          ...prevData,
-          pages: prevData.pages.map((page) => ({
-            ...page,
-            data: page.data.map((todo) => (todo.toDoId === data.toDoId ? data : todo)),
-          })),
-        }),
-      );
-    },
+  const { updateTodoMutate } = useUpdateTodo(toDoId, squadId, selectedDay, {
+    onSuccess: () => successToast('수정에 성공했어요'),
     onError: (error, data, context) => {
       failedToast('수정에 실패했어요');
       if (context?.oldData) {

--- a/src/hooks/mutations/useUpdateTodo.tsx
+++ b/src/hooks/mutations/useUpdateTodo.tsx
@@ -7,6 +7,7 @@ import { optimisticUpdateMutateHandler } from '@/utils';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useUpdateTodo = (
+  toDoId: number,
   squadId: number,
   selectedDay: string,
   options: MutateOptionsType<
@@ -18,10 +19,24 @@ export const useUpdateTodo = (
   const queryClient = useQueryClient();
   const { mutate: updateTodoMutate } = useMutation({
     mutationFn: updateTodo,
-    onMutate: async () => {
+    onMutate: async ({ newTodo }) => {
       const oldData = await optimisticUpdateMutateHandler<InfiniteQueryData<ApiResponse<ToDoDetail[]>>>(
         queryClient,
         todoKeys.todos(squadId, selectedDay),
+        (prevData: InfiniteQueryData<ApiResponse<ToDoDetail[]>>) => {
+          const todo = {
+            ...newTodo,
+            toDoId,
+          };
+
+          return {
+            ...prevData,
+            pages: prevData.pages.map((page) => ({
+              ...page,
+              data: page.data.map((prevTodo) => (prevTodo.toDoId === toDoId ? todo : prevTodo)),
+            })),
+          };
+        },
       );
 
       return { oldData };


### PR DESCRIPTION
## 작업 사항
- `onSusccess`에서 처리하던 낙관적 업데이트를 `onMutate`에서 처리  

### 추가 정보
- 업데이트 시 타입을 맞추기 위해 `toDoId` 매개변수로 전달

## 관련 이슈
close #136 