### PR TITLE
Refactor:  투두리스트 캐싱 최적화

### DIFF
--- a/src/Pages/SquadDetailPage.tsx
+++ b/src/Pages/SquadDetailPage.tsx
@@ -3,11 +3,11 @@ import { SquadDetailMemberList } from '@/components/Member';
 import { TodoForm, TodoList } from '@/components/Todo';
 import { TODO_PAGE_SIZE, TODO_STATUS } from '@/constants/todo';
 import { useUserCookie } from '@/hooks';
-import { squadDetailQueryOptions, todoInfiniteQueryOptions, todoKeys } from '@/hooks/queries';
+import { squadDetailQueryOptions, todoInfiniteQueryOptions } from '@/hooks/queries';
 import { useDayStore, useMemberStore, useSquadStore } from '@/stores';
 import { mobileMediaQuery, pcMediaQuery } from '@/styles/breakpoints';
 import { css, Theme } from '@emotion/react';
-import { useInfiniteQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -25,8 +25,6 @@ const SquadDetailPage = () => {
 
   const me = squadDetail?.squadMembers?.find((member) => member.memberId === user?.id);
   const isMeSelected = !selectedMember || selectedMember.squadMemberId === me?.squadMemberId;
-
-  const queryClient = useQueryClient();
 
   const payload = {
     startDate: selectedDay,
@@ -71,14 +69,6 @@ const SquadDetailPage = () => {
       setProgressRate(newProgressRate);
     }
   }, [todos, todoCount, progressRate]);
-
-  useEffect(
-    () => () =>
-      queryClient.removeQueries({
-        queryKey: todoKeys.todos(squadId, selectedDay),
-      }),
-    [selectedDay, selectedMember],
-  );
 
   return (
     <section css={containerStyle}>

--- a/src/components/Todo/TodoList.tsx
+++ b/src/components/Todo/TodoList.tsx
@@ -48,7 +48,7 @@ const TodoItem = ({ todo }: { todo: ToDoDetail }) => {
 
   const queryClient = useQueryClient();
   // TODO 상태 및 내용 수정 로직 공유
-  const { updateTodoMutate } = useUpdateTodo(toDoId, squadId, selectedDay, {
+  const { updateTodoMutate } = useUpdateTodo(squadId, selectedDay, {
     onSuccess: () => successToast('수정에 성공했어요'),
     onError: (error, data, context) => {
       failedToast('수정에 실패했어요');

--- a/src/hooks/mutations/useUpdateTodo.tsx
+++ b/src/hooks/mutations/useUpdateTodo.tsx
@@ -7,7 +7,6 @@ import { optimisticUpdateMutateHandler } from '@/utils';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useUpdateTodo = (
-  toDoId: number,
   squadId: number,
   selectedDay: string,
   options: MutateOptionsType<
@@ -19,7 +18,7 @@ export const useUpdateTodo = (
   const queryClient = useQueryClient();
   const { mutate: updateTodoMutate } = useMutation({
     mutationFn: updateTodo,
-    onMutate: async ({ newTodo }) => {
+    onMutate: async ({ newTodo, toDoId }) => {
       const oldData = await optimisticUpdateMutateHandler<InfiniteQueryData<ApiResponse<ToDoDetail[]>>>(
         queryClient,
         todoKeys.todos(squadId, selectedDay),

--- a/src/hooks/queries/todoQueries.tsx
+++ b/src/hooks/queries/todoQueries.tsx
@@ -34,4 +34,5 @@ export const todoInfiniteQueryOptions = (
     initialPageParam: 1,
     select: (data) => (data.pages ?? []).flatMap((page) => page.data),
     refetchOnWindowFocus: false,
+    staleTime: 300000,
   });


### PR DESCRIPTION
## 작업 사항
- `removeQueries` 로직이 매번 재조회 하는 것보다 불필요한 네트워크 요청이라 판단하여 제거
  - `staleTime` 조정
- `mutate` 함수의 `toDoId`를 활용하여 `useUpdateTodo` 훅의 불필요한 매개변수 제거

## 관련 이슈
close #138 