### PR TITLE
Fix: 투두리스트 조회 쿼리키 수정

### DIFF
--- a/src/components/Todo/TodoForm.tsx
+++ b/src/components/Todo/TodoForm.tsx
@@ -1,6 +1,6 @@
 import { Form } from '@/components/common';
 import { TODO_TYPES } from '@/constants/todo';
-import { useToastHandler } from '@/hooks';
+import { useToastHandler, useValidatedUser } from '@/hooks';
 import { useCreateTodo } from '@/hooks/mutations';
 import { todoKeys } from '@/hooks/queries';
 import { InfiniteQueryData } from '@/hooks/queries/types';
@@ -10,14 +10,16 @@ import { useQueryClient } from '@tanstack/react-query';
 import { FormEvent, KeyboardEventHandler, useCallback, useState } from 'react';
 
 const TodoForm = ({ squadId, selectedDay }: { squadId: number; selectedDay: string }) => {
+  const { userId } = useValidatedUser();
   const [contents, setContents] = useState('');
   const { successToast, failedToast, warningToast } = useToastHandler();
   const queryClient = useQueryClient();
+
   const { createTodoMutate } = useCreateTodo({
     onSuccess: async ({ data }) => {
       successToast('투두 등록에 성공했어요');
       queryClient.setQueryData(
-        todoKeys.todos(squadId, selectedDay),
+        todoKeys.todosByMember(squadId, selectedDay, userId),
         (prevData: InfiniteQueryData<ApiResponse<ToDoDetail[]>>) => ({
           ...prevData,
           pages: prevData.pages.map((page, index) => (index === 0 ? { ...page, data: [data, ...page.data] } : page)),

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,5 +3,6 @@ import { useModal } from '@/hooks/useModal';
 import useOpenToggle from '@/hooks/useOpenToggle';
 import useToastHandler from '@/hooks/useToastHandler';
 import useUserCookie from '@/hooks/useUserCookie';
+import useValidatedUser from '@/hooks/useValidatedUser';
 
-export { useInfinite, useModal, useOpenToggle, useToastHandler, useUserCookie };
+export { useInfinite, useModal, useOpenToggle, useToastHandler, useUserCookie, useValidatedUser };

--- a/src/hooks/mutations/useDeleteTodo.tsx
+++ b/src/hooks/mutations/useDeleteTodo.tsx
@@ -2,13 +2,12 @@ import { deleteTodo } from '@/apis';
 import { DeleteTodoParamType, MutateOptionsType } from '@/hooks/mutations/types';
 import { todoKeys } from '@/hooks/queries';
 import { InfiniteQueryData } from '@/hooks/queries/types';
-import { ApiResponse, ToDoDetail } from '@/types';
+import { ApiResponse, ToDoDetail, TodoQueryParams } from '@/types';
 import { optimisticUpdateMutateHandler } from '@/utils';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const useDeleteTodo = (
-  squadId: number,
-  selectedDay: string,
+  queryParams: TodoQueryParams,
   options: MutateOptionsType<
     ApiResponse<{ toDoId: number }>,
     DeleteTodoParamType,
@@ -19,9 +18,10 @@ const useDeleteTodo = (
   const { mutate: deleteTodoMuate } = useMutation({
     mutationFn: deleteTodo,
     onMutate: async (data) => {
+      const { squadId, selectedDay, userId } = queryParams;
       const oldData = await optimisticUpdateMutateHandler<InfiniteQueryData<ApiResponse<ToDoDetail[]>>>(
         queryClient,
-        todoKeys.todos(squadId, selectedDay),
+        todoKeys.todosByMember(squadId, selectedDay, userId),
         (prevData) => ({
           ...prevData,
           pages: prevData.pages.map((page) => ({

--- a/src/hooks/mutations/useUpdateTodo.tsx
+++ b/src/hooks/mutations/useUpdateTodo.tsx
@@ -2,13 +2,12 @@ import { updateTodo } from '@/apis';
 import { MutateOptionsType, UpdateTodoParamType } from '@/hooks/mutations/types';
 import { todoKeys } from '@/hooks/queries';
 import { InfiniteQueryData } from '@/hooks/queries/types';
-import { ApiResponse, CreateAndUpdateResponseType, ToDoDetail } from '@/types';
+import { ApiResponse, CreateAndUpdateResponseType, ToDoDetail, TodoQueryParams } from '@/types';
 import { optimisticUpdateMutateHandler } from '@/utils';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useUpdateTodo = (
-  squadId: number,
-  selectedDay: string,
+  queryParams: TodoQueryParams,
   options: MutateOptionsType<
     ApiResponse<CreateAndUpdateResponseType>,
     UpdateTodoParamType,
@@ -19,9 +18,10 @@ export const useUpdateTodo = (
   const { mutate: updateTodoMutate } = useMutation({
     mutationFn: updateTodo,
     onMutate: async ({ newTodo, toDoId }) => {
+      const { squadId, selectedDay, userId } = queryParams;
       const oldData = await optimisticUpdateMutateHandler<InfiniteQueryData<ApiResponse<ToDoDetail[]>>>(
         queryClient,
-        todoKeys.todos(squadId, selectedDay),
+        todoKeys.todosByMember(squadId, selectedDay, userId),
         (prevData: InfiniteQueryData<ApiResponse<ToDoDetail[]>>) => {
           const todo = {
             ...newTodo,

--- a/src/hooks/queries/todoQueries.tsx
+++ b/src/hooks/queries/todoQueries.tsx
@@ -4,7 +4,6 @@ import { infiniteQueryOptions } from '@tanstack/react-query';
 
 export const todoKeys = {
   todos: (squadId: number, day: string) => ['todoList', squadId, day] as const,
-  todoById: (squadId: number, day: string, todoId: number) => [...todoKeys.todos(squadId, day), todoId] as const,
   todosByMember: (squadId: number, day: string, memberId: number) => [...todoKeys.todos(squadId, day), memberId],
 };
 
@@ -15,7 +14,7 @@ export const todoInfiniteQueryOptions = (
   queryParams: Omit<GetTodoRequestPayload, 'lastToDoId'>,
 ) =>
   infiniteQueryOptions({
-    queryKey: todoKeys.todos(squadId, selectedDay),
+    queryKey: todoKeys.todosByMember(squadId, selectedDay, squadMemberId),
     queryFn: ({ pageParam }) =>
       getTodoList({
         squadMemberId,

--- a/src/hooks/useValidatedUser.tsx
+++ b/src/hooks/useValidatedUser.tsx
@@ -1,0 +1,12 @@
+import useUserCookie from '@/hooks/useUserCookie';
+import { assert } from '@/utils';
+
+const useValidatedUser = () => {
+  const { user } = useUserCookie();
+
+  assert(user !== null, 401);
+
+  return { userId: user.id };
+};
+
+export default useValidatedUser;

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -15,6 +15,12 @@ export type ToDoDetail = {
 
 export type TodoStatus = (typeof TODO_STATUS)[keyof typeof TODO_STATUS];
 
+export type TodoQueryParams = {
+  squadId: number;
+  selectedDay: string;
+  userId: number;
+};
+
 export type GetTodoRequestParams = {
   squadMemberId: number;
   payload: GetTodoRequestPayload;

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,0 +1,7 @@
+import { StatusError } from '@/utils';
+
+export function assert(condition: boolean, statusCode: number, message?: string): asserts condition {
+  if (!condition) {
+    throw new StatusError(statusCode, message);
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,8 @@
+import { assert } from '@/utils/assert';
 import { getDaysInMonth } from '@/utils/getDaysInMonth';
 import { getPriority } from '@/utils/getPriority';
 import { handleKeyDown } from '@/utils/handleKeyDown';
 import { optimisticUpdateMutateHandler } from '@/utils/optimisticUpdateMutateHandler';
+import { StatusError } from '@/utils/statusError';
 
-export { getDaysInMonth, getPriority, handleKeyDown, optimisticUpdateMutateHandler };
+export { assert, getDaysInMonth, getPriority, handleKeyDown, optimisticUpdateMutateHandler, StatusError };

--- a/src/utils/statusError.ts
+++ b/src/utils/statusError.ts
@@ -1,0 +1,13 @@
+export class StatusError extends Error {
+  response: {
+    status: number;
+  };
+
+  constructor(status: number, message?: string) {
+    super(message);
+    this.response = {
+      status,
+    };
+    this.name = 'StatusError';
+  }
+}


### PR DESCRIPTION
## 작업 사항
- API 변경에 따라 멤버별 투두리스트 조회를 위한 사용자 id를 받는 쿼리키로 변경
- 인증 여부에 따라 id를 반환하는 훅 추가
  - 특정 에러 상황을 처리하기 위한 커스텀 Error 객체 구현
  - 유효성 검사를 위한 assert 함수 작성
- 투두리스트 조회 시 기존 매개변수 대신 사용자 인증 훅에서 반환된 사용자 id 사용

### 추가 정보
쿠키에 저장된 user 정보가 null인 경우, 상태 코드를 포함하는 커스텀 에러 객체를 이용하여 에러 바운더리에서 처리합니다.

## 관련 이슈
close #141 