### PR TITLE
Refactor: 모달 태그를 dialog로 변경하고 동작 로직 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { RootErrorFallback, ToastContainer } from '@/components/common';
-import { ModalProvider } from '@/context/ModalContext';
+import { ModalProvider } from '@/context/modal';
 import { useThemeStore } from '@/stores';
 import { darkTheme, globalStyles, lightTheme } from '@/styles';
 import { Global, ThemeProvider } from '@emotion/react';

--- a/src/components/Member/SelectMemberList.tsx
+++ b/src/components/Member/SelectMemberList.tsx
@@ -2,7 +2,7 @@ import { assignSquadLeader } from '@/apis';
 import { Check } from '@/assets/icons';
 import { IconWrapper } from '@/components';
 import { MemberProfile } from '@/components/Member';
-import { ActionPrompt } from '@/components/common/Modal/ModalContents';
+import { ActionModal } from '@/components/common/Modal/ModalContents';
 import { ROLE } from '@/constants/role';
 import { MEMBER_STYLE_TYPE } from '@/constants/squad';
 import { useModal } from '@/hooks';
@@ -62,7 +62,7 @@ const Member = ({ squadId, member }: { squadId: number; member: SquadMember }) =
       displayCancel: true,
     } as const;
 
-    const res = await openModal(ActionPrompt, undefined, assignInfo);
+    const res = await openModal(ActionModal, undefined, assignInfo);
     if (res.ok) {
       assignSquadLeaderMutate({ squadId, newLeaderId: member.memberId });
     } else {

--- a/src/components/common/Modal/ModalContents/ActionModal.tsx
+++ b/src/components/common/Modal/ModalContents/ActionModal.tsx
@@ -4,8 +4,8 @@ import { ModalButtonGroup, ModalContent, ModalTemplate } from '@/components/comm
 import { ActionModalContentProps } from '@/types';
 import { css, Theme } from '@emotion/react';
 
-const ActionPrompt = ({ onSubmit, onAbort, actionModal }: ActionModalContentProps) => (
-  <ModalTemplate isOverlay={true} onClose={onAbort}>
+const ActionModal = ({ onSubmit, onAbort, actionModal }: ActionModalContentProps) => (
+  <ModalTemplate isOverlay={true} onClose={onAbort} preventClick={false}>
     <ModalContent>
       <p css={descStyle}>{actionModal.message}</p>
       <ModalButtonGroup>
@@ -24,7 +24,7 @@ const ActionPrompt = ({ onSubmit, onAbort, actionModal }: ActionModalContentProp
   </ModalTemplate>
 );
 
-export default ActionPrompt;
+export default ActionModal;
 
 const descStyle = (theme: Theme) => css`
   padding: 36px 0;

--- a/src/components/common/Modal/ModalContents/index.ts
+++ b/src/components/common/Modal/ModalContents/index.ts
@@ -1,2 +1,2 @@
-export { default as ActionPrompt } from './ActionPrompt';
+export { default as ActionModal } from './ActionModal';
 export { default as SquadForm } from './SquadForm';

--- a/src/components/common/Modal/ModalTemplate/ModalTemplate.tsx
+++ b/src/components/common/Modal/ModalTemplate/ModalTemplate.tsx
@@ -25,14 +25,7 @@ const ModalTemplate = ({ children, onClose, styleType = 'common', ...rest }: Mod
     preventClick={rest.preventClick}
     transparent={rest.transparent}
   >
-    <div
-      className={`modal-container ${styleType}`}
-      onClick={(e) => e.stopPropagation()}
-      onKeyDown={(e) => e.stopPropagation()}
-      role="presentation"
-    >
-      {children}
-    </div>
+    <dialog className={`modal-container ${styleType}`}>{children}</dialog>
   </Container>
 );
 

--- a/src/components/common/Overlay/Overlay.tsx
+++ b/src/components/common/Overlay/Overlay.tsx
@@ -15,8 +15,7 @@ const Overlay = ({
   ...rest
 }: PropsWithChildren & OverlayProps) => {
   const handleClose = (e: MouseEvent<HTMLDivElement>) => {
-    e.stopPropagation();
-    if (onClose) {
+    if (e.target === e.currentTarget && onClose) {
       onClose();
     }
   };
@@ -25,9 +24,7 @@ const Overlay = ({
     <div
       css={[container, transparent && bgTransparent]}
       onClick={preventClick ? undefined : handleClose}
-      onKeyDown={() => {}}
-      role="button"
-      tabIndex={0}
+      role="presentation"
       {...rest}
     >
       {children}

--- a/src/components/common/Sidebar/Sidebar.tsx
+++ b/src/components/common/Sidebar/Sidebar.tsx
@@ -68,14 +68,8 @@ export const Sidebar = ({ closeSidebar }: { closeSidebar: VoidFunction }) => {
       style={{
         justifyContent: 'flex-end',
       }}
-      role="dialog"
     >
-      <div
-        css={sidebarContainer}
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-        role="presentation"
-      >
+      <dialog css={sidebarContainer}>
         <header css={headerStyle}>
           <h1>스쿼드 관리</h1>
           <IconWrapper aria-label="Close sidebar" onClick={closeSidebar} role="button" css={commonButtonStyle}>
@@ -137,7 +131,7 @@ export const Sidebar = ({ closeSidebar }: { closeSidebar: VoidFunction }) => {
         <button css={exitButtonStyle} onClick={handleSquadExit}>
           나가기
         </button>
-      </div>
+      </dialog>
       <UpdateSquadNameModal />
       <DeleteSquadModal />
       <ExitSquadModal />

--- a/src/context/modal/context.ts
+++ b/src/context/modal/context.ts
@@ -1,0 +1,12 @@
+import { ModalType } from '@/types';
+import { createContext, MutableRefObject } from 'react';
+
+type ModalContextValue<P> = {
+  open: (modal: ModalType<P>) => void;
+  close: (id: string) => void;
+  modals: ModalType<P>[];
+  portalRef: MutableRefObject<HTMLDivElement | null>;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const modalContext = createContext<ModalContextValue<any> | null>(null);

--- a/src/context/modal/index.ts
+++ b/src/context/modal/index.ts
@@ -1,0 +1,5 @@
+import { modalContext } from '@/context/modal/context';
+import { ModalProvider } from '@/context/modal/provider';
+import { useModalContext } from '@/context/modal/useModalContext';
+
+export { modalContext, ModalProvider, useModalContext };

--- a/src/context/modal/provider.tsx
+++ b/src/context/modal/provider.tsx
@@ -1,26 +1,8 @@
+import { modalContext } from '@/context/modal/context';
 import { breakpoints, mobileMediaQuery, pcMediaQuery } from '@/styles/breakpoints';
 import { ModalParameters, ModalType } from '@/types';
 import { css } from '@emotion/react';
-import {
-  MutableRefObject,
-  PropsWithChildren,
-  createContext,
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-
-type ModalContextValue<P> = {
-  open: (modal: ModalType<P>) => void;
-  close: (id: string) => void;
-  modals: ModalType<P>[];
-  portalRef: MutableRefObject<HTMLDivElement | null>;
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const modalContext = createContext<ModalContextValue<any> | null>(null);
+import { PropsWithChildren, useCallback, useMemo, useRef, useState } from 'react';
 
 export const ModalProvider = ({ children }: PropsWithChildren) => {
   const [modals, setModals] = useState<ModalType<ModalParameters>[]>([]);
@@ -46,14 +28,6 @@ export const ModalProvider = ({ children }: PropsWithChildren) => {
       </div>
     </modalContext.Provider>
   );
-};
-
-export const useModalContext = () => {
-  const context = useContext(modalContext);
-  if (!context) {
-    throw new Error('modalContext is not available.');
-  }
-  return context;
 };
 
 const modalConatiner = css`

--- a/src/context/modal/useModalContext.tsx
+++ b/src/context/modal/useModalContext.tsx
@@ -1,0 +1,10 @@
+import { modalContext } from '@/context/modal/context';
+import { useContext } from 'react';
+
+export const useModalContext = () => {
+  const context = useContext(modalContext);
+  if (!context) {
+    throw new Error('modalContext is not available.');
+  }
+  return context;
+};

--- a/src/hooks/mutations/useDeleteSquad.tsx
+++ b/src/hooks/mutations/useDeleteSquad.tsx
@@ -1,5 +1,5 @@
 import { deleteSquad } from '@/apis';
-import { ActionPrompt } from '@/components/common/Modal/ModalContents';
+import { ActionModal } from '@/components/common/Modal/ModalContents';
 
 import { ExitAndDeleteSquadNameParamType, MutateOptionsType } from '@/hooks/mutations';
 import { useModal } from '@/hooks/useModal';
@@ -24,7 +24,7 @@ const useDeleteSquad = (
       displayCancel: true,
     } as const;
 
-    const res = await openModal(ActionPrompt, undefined, deleteInfo);
+    const res = await openModal(ActionModal, undefined, deleteInfo);
     if (res.ok) {
       deleteSquadMutate({ squadId });
     }

--- a/src/hooks/mutations/useExitSquad.tsx
+++ b/src/hooks/mutations/useExitSquad.tsx
@@ -1,5 +1,5 @@
 import { exitSquad } from '@/apis';
-import { ActionPrompt } from '@/components/common/Modal/ModalContents';
+import { ActionModal } from '@/components/common/Modal/ModalContents';
 
 import { ExitAndDeleteSquadNameParamType, MutateOptionsType } from '@/hooks/mutations';
 import { useModal } from '@/hooks/useModal';
@@ -33,7 +33,7 @@ const useExitSquad = (
       displayCancel: true,
     } as const;
 
-    const res = await openModal(ActionPrompt, undefined, hasMembers && isLeader ? checkInfo : exitInfo);
+    const res = await openModal(ActionModal, undefined, hasMembers && isLeader ? checkInfo : exitInfo);
     if (res.ok && !hasMembers) {
       exitSquadMutate({ squadId });
     }

--- a/src/hooks/mutations/useRemoveUserFromSquad.tsx
+++ b/src/hooks/mutations/useRemoveUserFromSquad.tsx
@@ -1,5 +1,5 @@
 import { removeUserFromSquad } from '@/apis';
-import { ActionPrompt } from '@/components/common/Modal/ModalContents';
+import { ActionModal } from '@/components/common/Modal/ModalContents';
 
 import { MutateOptionsType, RemoveUserFromSquadParamType } from '@/hooks/mutations';
 import { useModal } from '@/hooks/useModal';
@@ -25,7 +25,7 @@ const useRemoveUserFromSquad = (
       displayCancel: true,
     } as const;
 
-    const res = await openModal(ActionPrompt, undefined, removeInfo);
+    const res = await openModal(ActionModal, undefined, removeInfo);
     if (res.ok) {
       deleteSquadMutate({ squadId, kickedMemberId: member.memberId });
     }

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,7 +1,7 @@
 import { Modal, ModalPortal } from '@/components/common/Modal';
+import { useModalContext } from '@/context/modal';
 import { ActionModalType } from '@/types';
 import { ComponentType, useCallback, useEffect, useId } from 'react';
-import { useModalContext } from 'src/context/ModalContext';
 
 export const useModal = () => {
   const context = useModalContext();

--- a/src/index.css
+++ b/src/index.css
@@ -16,6 +16,7 @@
   z-index: 999;
   background: white;
   padding: 28px;
+  margin: 0 24px;
   border-radius: 16px;
   position: relative;
   -webkit-box-shadow: -5px 10px 49px 0px rgba(36, 36, 36, 0.25);

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -203,6 +203,10 @@ export const globalStyles = (theme: Theme) => css`
     background: none;
   }
 
+  dialog {
+    all: unset;
+  }
+
   /* Add global styles */
 `;
 


### PR DESCRIPTION
## 작업 사항
- context 디렉토리 구조 개선
   - **context, provider, useContext 캡슐화** 훅을 목적별로 관리하기 위함
- 확인/삭제 등 재사용 되는 모달명 변경
   - ActionPrompt -> ActionModal
- 모달 배경 관련 태그를 `<dialog>` 태그로 변경하여 접근성 개선
   - <dialog> 기본 스타일 초기화
   - 변경 후 필요없는 이벤트 버블링 방지 로직 제걱
 - 오버레이에 포커스 되지 않도록 `role`을 `presentation`으로 변경
    - 이중모달에서 상위 모달 클릭 이벤트로 모두 닫히는 문제를 해결하기 위해 `currentTarget` 확인 로직 추가

## 관련 이슈
close #143 