### PR TITLE
Fix: 투두 생성/조회/삭제 시 조회 에러

### DIFF
--- a/src/Pages/SquadDetailPage.tsx
+++ b/src/Pages/SquadDetailPage.tsx
@@ -23,8 +23,9 @@ const SquadDetailPage = () => {
     ...squadDetailQueryOptions(squadId),
   }).data;
 
-  const me = squadDetail?.squadMembers?.find((member) => member.memberId === user?.id);
+  const me = squadDetail.squadMembers.find((member) => member.memberId === user?.id);
   const isMeSelected = !selectedMember || selectedMember.squadMemberId === me?.squadMemberId;
+  const squadMemberId = isMeSelected ? me!.squadMemberId : selectedMember!.squadMemberId;
 
   const payload = {
     startDate: selectedDay,
@@ -33,12 +34,7 @@ const SquadDetailPage = () => {
   };
 
   const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
-    todoInfiniteQueryOptions(
-      isMeSelected ? me!.squadMemberId : selectedMember!.squadMemberId,
-      squadId,
-      selectedDay,
-      payload,
-    ),
+    todoInfiniteQueryOptions(squadMemberId, squadId, selectedDay, payload),
   );
 
   const todos = data ?? [];
@@ -58,7 +54,7 @@ const SquadDetailPage = () => {
   }, [squadId]);
 
   useEffect(() => {
-    setSelectedMember(null);
+    setSelectedMember(me || null);
   }, []);
 
   useEffect(() => {
@@ -84,8 +80,14 @@ const SquadDetailPage = () => {
         <span>{!selectedMember ? user?.name : selectedMember.name}</span>
         <span>달성률: {progressRate}%</span>
       </div>
-      <TodoList todos={todos} loadMoreTodos={loadMoreTodos} hasNextPage={hasNextPage} isMeSelected={isMeSelected} />
-      {isMeSelected && <TodoForm squadId={squadId} selectedDay={selectedDay} />}
+      <TodoList
+        todos={todos}
+        loadMoreTodos={loadMoreTodos}
+        hasNextPage={hasNextPage}
+        isMeSelected={isMeSelected}
+        squadMemberId={squadMemberId}
+      />
+      {isMeSelected && <TodoForm squadId={squadId} selectedDay={selectedDay} squadMemberId={squadMemberId} />}
     </section>
   );
 };

--- a/src/components/Todo/TodoForm.tsx
+++ b/src/components/Todo/TodoForm.tsx
@@ -1,6 +1,6 @@
 import { Form } from '@/components/common';
 import { TODO_TYPES } from '@/constants/todo';
-import { useToastHandler, useValidatedUser } from '@/hooks';
+import { useToastHandler } from '@/hooks';
 import { useCreateTodo } from '@/hooks/mutations';
 import { todoKeys } from '@/hooks/queries';
 import { InfiniteQueryData } from '@/hooks/queries/types';
@@ -9,8 +9,15 @@ import { css, Theme } from '@emotion/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { FormEvent, KeyboardEventHandler, useCallback, useState } from 'react';
 
-const TodoForm = ({ squadId, selectedDay }: { squadId: number; selectedDay: string }) => {
-  const { userId } = useValidatedUser();
+const TodoForm = ({
+  squadId,
+  selectedDay,
+  squadMemberId,
+}: {
+  squadId: number;
+  selectedDay: string;
+  squadMemberId: number;
+}) => {
   const [contents, setContents] = useState('');
   const { successToast, failedToast, warningToast } = useToastHandler();
   const queryClient = useQueryClient();
@@ -19,7 +26,7 @@ const TodoForm = ({ squadId, selectedDay }: { squadId: number; selectedDay: stri
     onSuccess: async ({ data }) => {
       successToast('투두 등록에 성공했어요');
       queryClient.setQueryData(
-        todoKeys.todosByMember(squadId, selectedDay, userId),
+        todoKeys.todosByMember(squadId, selectedDay, squadMemberId),
         (prevData: InfiniteQueryData<ApiResponse<ToDoDetail[]>>) => ({
           ...prevData,
           pages: prevData.pages.map((page, index) => (index === 0 ? { ...page, data: [data, ...page.data] } : page)),

--- a/src/hooks/mutations/useDeleteTodo.tsx
+++ b/src/hooks/mutations/useDeleteTodo.tsx
@@ -18,10 +18,10 @@ const useDeleteTodo = (
   const { mutate: deleteTodoMuate } = useMutation({
     mutationFn: deleteTodo,
     onMutate: async (data) => {
-      const { squadId, selectedDay, userId } = queryParams;
+      const { squadId, selectedDay, squadMemberId } = queryParams;
       const oldData = await optimisticUpdateMutateHandler<InfiniteQueryData<ApiResponse<ToDoDetail[]>>>(
         queryClient,
-        todoKeys.todosByMember(squadId, selectedDay, userId),
+        todoKeys.todosByMember(squadId, selectedDay, squadMemberId),
         (prevData) => ({
           ...prevData,
           pages: prevData.pages.map((page) => ({

--- a/src/hooks/mutations/useUpdateTodo.tsx
+++ b/src/hooks/mutations/useUpdateTodo.tsx
@@ -18,10 +18,10 @@ export const useUpdateTodo = (
   const { mutate: updateTodoMutate } = useMutation({
     mutationFn: updateTodo,
     onMutate: async ({ newTodo, toDoId }) => {
-      const { squadId, selectedDay, userId } = queryParams;
+      const { squadId, selectedDay, squadMemberId } = queryParams;
       const oldData = await optimisticUpdateMutateHandler<InfiniteQueryData<ApiResponse<ToDoDetail[]>>>(
         queryClient,
-        todoKeys.todosByMember(squadId, selectedDay, userId),
+        todoKeys.todosByMember(squadId, selectedDay, squadMemberId),
         (prevData: InfiniteQueryData<ApiResponse<ToDoDetail[]>>) => {
           const todo = {
             ...newTodo,

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -18,7 +18,7 @@ export type TodoStatus = (typeof TODO_STATUS)[keyof typeof TODO_STATUS];
 export type TodoQueryParams = {
   squadId: number;
   selectedDay: string;
-  userId: number;
+  squadMemberId: number;
 };
 
 export type GetTodoRequestParams = {


### PR DESCRIPTION
## 원인
투두 생성/수정/삭제 시 전달하는 사용자 id가 스쿼드마다 동일한 `memberId`로 적용되어 발생

## 해결
- 스쿼드별로 다르게 부여되는 사용자 전용 `squadMemberId`로 매개변수 변경
- 파라미터 타입명을 수정하여 명확히 표기

## 관련 이슈
close #145 