### PR TITLE
Feat: 스쿼드 상세 페이지 진입 시 투두리스트 리페치 로직 추가

### DIFF
--- a/src/Pages/SquadDetailPage.tsx
+++ b/src/Pages/SquadDetailPage.tsx
@@ -33,9 +33,12 @@ const SquadDetailPage = () => {
     pageSize: TODO_PAGE_SIZE,
   };
 
-  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
-    todoInfiniteQueryOptions(squadMemberId, squadId, selectedDay, payload),
-  );
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    refetch: refetchTodos,
+  } = useInfiniteQuery(todoInfiniteQueryOptions(squadMemberId, squadId, selectedDay, payload));
 
   const todos = data ?? [];
 
@@ -55,6 +58,10 @@ const SquadDetailPage = () => {
 
   useEffect(() => {
     setSelectedMember(me || null);
+  }, []);
+
+  useEffect(() => {
+    refetchTodos();
   }, []);
 
   useEffect(() => {

--- a/src/components/Todo/TodoList.tsx
+++ b/src/components/Todo/TodoList.tsx
@@ -43,12 +43,11 @@ const TodoItem = ({ todo, squadMemberId }: { todo: ToDoDetail; squadMemberId: nu
   const squadId = useSquadStore((state) => state.currentSquadId);
   const theme = useTheme();
   const { toDoAt, toDoId, contents, toDoStatus } = todo;
-  const [currentToDoStatus, setCurrentToDoStatus] = useState(todo.toDoStatus);
   const selectedDay = useDayStore((state) => state.selectedDay);
   const [isEditMode, setIsEditMode] = useState(false);
   const [isDeleteMode, setIsDeleteMode] = useState(false);
   const [newContents, setNewContents] = useState(contents);
-  const isCompleted = currentToDoStatus === TODO_STATUS.COMPLETED;
+  const isCompleted = toDoStatus === TODO_STATUS.COMPLETED;
   const { successToast, failedToast } = useToastHandler();
 
   const queryParams: TodoQueryParams = {
@@ -79,13 +78,12 @@ const TodoItem = ({ todo, squadMemberId }: { todo: ToDoDetail; squadMemberId: nu
   });
 
   const toggleTodoStatus = () => {
-    const newStatus = currentToDoStatus === TODO_STATUS.PENDING ? TODO_STATUS.COMPLETED : TODO_STATUS.PENDING;
+    const newStatus = toDoStatus === TODO_STATUS.PENDING ? TODO_STATUS.COMPLETED : TODO_STATUS.PENDING;
     const newTodo: UpdateTodoRequest = {
       toDoAt,
       toDoStatus: newStatus,
       contents,
     };
-    setCurrentToDoStatus(newStatus);
     updateTodoMutate({ toDoId, newTodo });
   };
 

--- a/src/components/Todo/TodoList.tsx
+++ b/src/components/Todo/TodoList.tsx
@@ -171,7 +171,14 @@ const TodoItem = ({ todo, squadMemberId }: { todo: ToDoDetail; squadMemberId: nu
               role="presentation"
             >
               <Button id="edit-btn" text="수정" variant="confirm" onClick={handleEditContents} />
-              <Button text="취소" variant="default" onClick={() => setIsEditMode(false)} />
+              <Button
+                text="취소"
+                variant="default"
+                onClick={() => {
+                  setNewContents(contents);
+                  setIsEditMode(false);
+                }}
+              />
             </div>
           )}
         </li>


### PR DESCRIPTION
## 작업 사항
- 투두에 동시 접근 시 데이터 동기화를 위한 투두리스트 리페치 로직 추가
- 투두 완료 여부 변경 시 다른 브라우저에서의 동기화 타이밍 불일치 문제 해결
- 투두 수정을 위해 데이터 입력중 취소 시 상태가 유지되는 문제 해결

### 추가 정보
투두 관련 버그를 함께 수정합니다.

## 관련 이슈
close #148 #149 