### PR TITLE
Feat: 테스트 로그인 로직을 구글 소셜 로그인으로 변경

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Configure Git user
+        run: |
+          git config --global user.name "k-jeonghee"
+          git config --global user.email "heestory1992@gmail.com"
+
       - name: Add upstream repository
         run: |
           git remote add upstream https://github.com/Eggmeoni-na/scrumble-FE.git

--- a/src/Pages/GoogleOAuthLoginPage.tsx
+++ b/src/Pages/GoogleOAuthLoginPage.tsx
@@ -1,10 +1,12 @@
 import { signInOrSignUp } from '@/apis/auth';
+import { useUserCookie } from '@/hooks';
 import { OAuthRequestParams } from '@/types/auth';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const GoogleOAuthCallbackPage = () => {
   const navigate = useNavigate();
+  const { setCookie } = useUserCookie();
 
   useEffect(() => {
     const handleGoogleOAuth = async () => {
@@ -28,7 +30,15 @@ const GoogleOAuthCallbackPage = () => {
       try {
         const response = await signInOrSignUp(authData);
         if (response.status === 200) {
-          // TODO: 인증 정보 전역 관리
+          const { id, name } = response.data.data;
+          setCookie(
+            'user',
+            { id, name },
+            {
+              path: '/',
+              sameSite: 'strict',
+            },
+          );
           navigate('/');
         }
       } catch (error) {

--- a/src/Pages/LoginPage.tsx
+++ b/src/Pages/LoginPage.tsx
@@ -1,38 +1,12 @@
-import { generateTempSession } from '@/apis';
-import { useUserCookie } from '@/hooks';
+import { getOAuthUrl } from '@/apis';
 import { pcMediaQuery } from '@/styles/breakpoints';
-import { AuthUser } from '@/types';
 import { css } from '@emotion/react';
-import { AxiosResponse } from 'axios';
-import { useNavigate } from 'react-router-dom';
 
 const LoginPage = () => {
-  const navigate = useNavigate();
-  const { setCookie } = useUserCookie();
-
   const handleGoogleLogin = async () => {
     try {
-      // TODO: 테스트 완료 후 구글 로그인으로 변경 예정
-      const response: AxiosResponse<{ data: AuthUser }> = await generateTempSession();
-      const { status, data } = response;
-      if (status === 200) {
-        const { id, name } = data.data;
-
-        setCookie(
-          'user',
-          { id, name },
-          {
-            path: '/',
-            sameSite: 'strict',
-          },
-        );
-
-        navigate('/squads', { replace: true });
-        return;
-      } else {
-        // TODO: 세션 발급 실패 에러 처리
-        console.error('Failed to generate session:', status);
-      }
+      const response = await getOAuthUrl('GOOGLE');
+      window.location.href = `${response.data.redirectUrl}`;
     } catch (error) {
       // TODO: 로그인 실패 에러 안내
       console.error('Failed to fetch Google OAuth URL', error);

--- a/src/Router/router.tsx
+++ b/src/Router/router.tsx
@@ -85,7 +85,7 @@ export const router = createBrowserRouter([
         ),
       },
       {
-        path: '/login/oauth2/code/google',
+        path: '/auth',
         element: <GoogleOAuthCallbackPage />,
       },
     ],

--- a/src/context/notification/provider.tsx
+++ b/src/context/notification/provider.tsx
@@ -29,7 +29,6 @@ export const NotificationProvider = ({ children }: PropsWithChildren) => {
 
     eventSource.onerror = () => {
       console.error('SSE 연결이 끊어졌습니다. 재연결을 시도합니다.');
-      eventSource.close();
     };
 
     return () => eventSource.close();


### PR DESCRIPTION
## 작업 사항
- SSE 연결 끊김 시 재연결 되도록 close 호출 제거
- 하드코딩 된 로그인 로직을 소셜 로그인으로 변경
- 소셜 로그인 callback url 변경 반영

### 추가 정보
- 개발 레포의 동기화 조건을 main 브랜치로 변경

## 관련 이슈
close #151 