### PR TITLE
Refactor: 스쿼드 멤버 목록 렌더링 로직 개선

### DIFF
--- a/src/Pages/SquadDetailPage.tsx
+++ b/src/Pages/SquadDetailPage.tsx
@@ -19,9 +19,12 @@ const SquadDetailPage = () => {
   const { selectedDay, setSelectedDay } = useDayStore((state) => state);
   const { selectedMember, setSelectedMember } = useMemberStore((state) => state);
 
-  const { data: squadDetail } = useSuspenseQuery({
+  const {
+    data: { data: squadDetail },
+    refetch: refetchSquadDetail,
+  } = useSuspenseQuery({
     ...squadDetailQueryOptions(squadId),
-  }).data;
+  });
 
   const me = squadDetail.squadMembers.find((member) => member.memberId === user?.id);
   const isMeSelected = !selectedMember || selectedMember.squadMemberId === me?.squadMemberId;
@@ -61,6 +64,7 @@ const SquadDetailPage = () => {
   }, []);
 
   useEffect(() => {
+    refetchSquadDetail();
     refetchTodos();
   }, []);
 

--- a/src/components/Member/SidebarMemberList.tsx
+++ b/src/components/Member/SidebarMemberList.tsx
@@ -4,16 +4,13 @@ import { MemberProfile } from '@/components/Member';
 import { commonButtonStyle } from '@/components/common/Sidebar';
 import { ROLE } from '@/constants/role';
 import { MEMBER_STYLE_TYPE } from '@/constants/squad';
-import { useUserCookie } from '@/hooks';
 import { useRemoveUserFromSquad } from '@/hooks/mutations';
 import { squadKeys } from '@/hooks/queries';
 import { useSquadStore, useToastStore } from '@/stores';
 import { mobileMediaQuery, pcMediaQuery } from '@/styles/breakpoints';
 import { SquadMember } from '@/types';
-import { getPriority } from '@/utils';
 import { css } from '@emotion/react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useMemo } from 'react';
 
 const SidebarMemberList = ({
   members,
@@ -23,16 +20,10 @@ const SidebarMemberList = ({
   myRole: (typeof ROLE)[keyof typeof ROLE];
 }) => {
   const isLeader = myRole === ROLE.LEADER;
-  const { user } = useUserCookie();
-
-  const sortedMembers = useMemo(
-    () => [...members].sort((a, b) => getPriority(a, user!.id) - getPriority(b, user!.id)),
-    [],
-  );
 
   return (
     <ul css={containerStyle}>
-      {sortedMembers.map((member) => (
+      {members.map((member) => (
         <Member key={member.memberId} member={member} showIcon={isLeader && member.squadMemberRole === ROLE.NORMAL} />
       ))}
     </ul>

--- a/src/components/Member/SquadDetailMemberList.tsx
+++ b/src/components/Member/SquadDetailMemberList.tsx
@@ -5,7 +5,6 @@ import { useMemberStore } from '@/stores';
 import { scrollBarStyle } from '@/styles/globalStyles';
 import { SquadMember } from '@/types';
 import { css } from '@emotion/react';
-import { useMemo } from 'react';
 
 type Props = {
   squadMembers: SquadMember[];
@@ -13,7 +12,7 @@ type Props = {
 
 const SquadDetailMemberList = ({ squadMembers }: Props) => {
   const { user } = useUserCookie();
-  const sortedMembers = useMemo(() => [...squadMembers].sort((a) => (a.memberId === user?.id ? -1 : 0)), []);
+  const sortedMembers = [...squadMembers].sort((a) => (a.memberId === user?.id ? -1 : 0));
 
   return (
     <ul css={containerStyle}>

--- a/src/components/common/Sidebar/Sidebar.tsx
+++ b/src/components/common/Sidebar/Sidebar.tsx
@@ -3,10 +3,11 @@ import { IconWrapper } from '@/components';
 import { SidebarMemberList } from '@/components/Member';
 import { Overlay } from '@/components/common/Overlay';
 import { ROLE } from '@/constants/role';
+import { useUserCookie } from '@/hooks';
 import { useDeleteSquad, useExitSquad, useUpdateSquadName } from '@/hooks/mutations';
 import { squadDetailQueryOptions, squadKeys } from '@/hooks/queries';
 import { useSquadStore, useToastStore } from '@/stores';
-import { handleKeyDown } from '@/utils';
+import { getPriority, handleKeyDown } from '@/utils';
 import { css, Theme } from '@emotion/react';
 import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
@@ -15,11 +16,17 @@ export const Sidebar = ({ closeSidebar }: { closeSidebar: VoidFunction }) => {
   const squadId = useSquadStore((state) => state.currentSquadId);
   const navigate = useNavigate();
   const createToast = useToastStore((state) => state.createToast);
+  const { user } = useUserCookie();
 
   const { data: squadDetail } = useSuspenseQuery({
     ...squadDetailQueryOptions(squadId),
+    select: (data) => ({
+      ...data,
+      squadMembers: data.data.squadMembers.sort((a, b) => getPriority(a, user!.id) - getPriority(b, user!.id)),
+    }),
     refetchOnMount: false,
   }).data;
+
   const { squadName, squadMembers, mySquadMemberRole } = squadDetail;
   const isLeader = mySquadMemberRole === ROLE.LEADER;
 

--- a/src/hooks/queries/squadQueries.tsx
+++ b/src/hooks/queries/squadQueries.tsx
@@ -18,4 +18,5 @@ export const squadDetailQueryOptions = (squadId: number) =>
     queryKey: squadKeys.squadDetail(squadId),
     queryFn: () => getSquadDetail(squadId),
     refetchOnWindowFocus: false,
+    staleTime: 300000,
   });


### PR DESCRIPTION
## 작업 사항
- 멤버 목록을 props로 받아서 정렬하던 로직을 `select`로 바로 반환하도록 변경
- 투두리스트 조회를 위한 멤버 목록 정렬 로직의 `useMemo` 제거
- 스쿼드 상세 페이지의 `staleTime`을 5분으로 지정
   - 동기화를 위해 상세 페이지를 렌더링 할 때마다 `refetch` 적용

## 관련 이슈
close #168 #169 