### PR TITLE
Fix: 에러 Fallback UI 로직 개선 및 Axios 응답 Interceptor 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { RootErrorFallback, ToastContainer } from '@/components/common';
+import { Loading, RootErrorFallback, ToastContainer } from '@/components/common';
 import { ModalProvider } from '@/context/modal';
 import { NotificationProvider } from '@/context/notification/provider';
 import { useThemeStore } from '@/stores';
@@ -6,7 +6,9 @@ import { darkTheme, globalStyles, lightTheme } from '@/styles';
 import { Global, ThemeProvider } from '@emotion/react';
 import { QueryClient, QueryClientProvider, useQueryErrorResetBoundary } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
+
 import { Outlet } from 'react-router-dom';
 
 const queryClient = new QueryClient({
@@ -29,7 +31,9 @@ function App() {
           <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>
             <Global styles={globalStyles} />
             <ErrorBoundary FallbackComponent={RootErrorFallback} onReset={reset}>
-              <Outlet />
+              <Suspense fallback={<Loading />}>
+                <Outlet />
+              </Suspense>
             </ErrorBoundary>
             <ToastContainer />
           </ThemeProvider>

--- a/src/Router/router.tsx
+++ b/src/Router/router.tsx
@@ -1,6 +1,6 @@
 import App from '@/App';
 import { SquadIdGuard } from '@/components';
-import { Loading } from '@/components/common';
+import { FallbackWrapper } from '@/components/common/ErrorBoundary';
 import { LoginLayout, MainLayout } from '@/components/layouts';
 import ProtectedRoute from '@/components/ProtectedRoute';
 import {
@@ -14,9 +14,8 @@ import {
   SquadDetailPage,
   SquadPage,
 } from '@/Pages';
-import { Suspense } from 'react';
 
-import { createBrowserRouter, Outlet } from 'react-router-dom';
+import { createBrowserRouter } from 'react-router-dom';
 
 export const router = createBrowserRouter([
   {
@@ -24,63 +23,66 @@ export const router = createBrowserRouter([
     element: <App />,
     children: [
       {
-        path: '/',
+        index: true,
         element: (
           <ProtectedRoute>
-            <MainLayout>
-              <Outlet />
-            </MainLayout>
+            <FallbackWrapper>
+              <HomePage />
+            </FallbackWrapper>
           </ProtectedRoute>
         ),
+      },
+      {
+        path: 'squads',
         children: [
           {
             index: true,
-            element: <HomePage />,
-          },
-          {
-            path: '/squads',
             element: (
-              <Suspense fallback={<Loading />}>
+              <FallbackWrapper>
                 <SquadPage />
-              </Suspense>
+              </FallbackWrapper>
             ),
           },
           {
-            path: '/squads/:squadId',
+            path: ':squadId',
             element: (
-              <Suspense fallback={<Loading />}>
+              <FallbackWrapper>
                 <SquadDetailPage />
-              </Suspense>
+              </FallbackWrapper>
             ),
           },
           {
-            path: '/squads/:squadId/members',
+            path: ':squadId/members',
             element: (
               <SquadIdGuard>
-                <SelectMemberPage />
+                <FallbackWrapper>
+                  <SelectMemberPage />
+                </FallbackWrapper>
               </SquadIdGuard>
             ),
           },
           {
-            path: '/squads/:squadId/invite',
+            path: ':squadId/invite',
             element: (
               <SquadIdGuard>
-                <InvitePage />
+                <FallbackWrapper>
+                  <InvitePage />
+                </FallbackWrapper>
               </SquadIdGuard>
-            ),
-          },
-          {
-            path: '/me',
-            element: (
-              <Suspense fallback={<Loading />}>
-                <MyPage />
-              </Suspense>
             ),
           },
         ],
       },
       {
-        path: '/login',
+        path: 'me',
+        element: (
+          <MainLayout>
+            <MyPage />
+          </MainLayout>
+        ),
+      },
+      {
+        path: 'login',
         element: (
           <LoginLayout>
             <LoginPage />
@@ -88,13 +90,13 @@ export const router = createBrowserRouter([
         ),
       },
       {
-        path: '/auth',
+        path: 'auth',
         element: <GoogleOAuthCallbackPage />,
       },
     ],
   },
   {
-    path: '/*',
+    path: '*',
     element: <NotFoundPage />,
   },
 ]);

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosError, AxiosResponse } from 'axios';
 
 export const baseURL = import.meta.env.MODE === 'development' ? '' : import.meta.env.VITE_API_URL;
 
@@ -10,6 +10,11 @@ export const instance = axios.create({
   },
   withCredentials: true,
 });
+
+const responseInterceptor = (response: AxiosResponse): AxiosResponse => response;
+const errorHandler = (error: AxiosError): Promise<AxiosError> => Promise.reject(error);
+
+instance.interceptors.response.use(responseInterceptor, errorHandler);
 
 export * from './auth';
 export * from './squad';

--- a/src/components/common/ErrorBoundary/FallbackWrapper.tsx
+++ b/src/components/common/ErrorBoundary/FallbackWrapper.tsx
@@ -1,0 +1,15 @@
+import { ModalFallback } from '@/components/common/ErrorBoundary';
+import { Loading } from '@/components/common/Loading';
+import { MainLayout } from '@/components/layouts';
+import { PropsWithChildren, Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+
+const FallbackWrapper = ({ children }: PropsWithChildren) => (
+  <ErrorBoundary FallbackComponent={ModalFallback}>
+    <Suspense fallback={<Loading />}>
+      <MainLayout>{children}</MainLayout>
+    </Suspense>
+  </ErrorBoundary>
+);
+
+export default FallbackWrapper;

--- a/src/components/common/ErrorBoundary/ModalFallback.tsx
+++ b/src/components/common/ErrorBoundary/ModalFallback.tsx
@@ -1,0 +1,93 @@
+import { ActionModal } from '@/components/common/Modal';
+import { useModal, useUserCookie } from '@/hooks';
+import { breakpoints, mobileMediaQuery, pcMediaQuery } from '@/styles/breakpoints';
+import { ActionModalType, ApiErrorResponse } from '@/types';
+import { handleNavigate } from '@/utils';
+import { css, Theme } from '@emotion/react';
+import { useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { useEffect } from 'react';
+import { FallbackProps } from 'react-error-boundary';
+import { useNavigate } from 'react-router-dom';
+
+interface Props extends FallbackProps {
+  error: AxiosError<ApiErrorResponse>;
+  queryKey?: readonly (string | number)[];
+}
+
+const ModalFallback = ({ error, resetErrorBoundary, queryKey }: Props) => {
+  const navigate = useNavigate();
+  const { openModal, ModalContainer } = useModal();
+  const { clearCookie } = useUserCookie();
+  const queryClient = useQueryClient();
+
+  const handleError = async (modalOptions: ActionModalType, redirectPath: string | number) => {
+    const res = await openModal(ActionModal, undefined, modalOptions);
+    if (res.ok) {
+      resetErrorBoundary();
+      if (queryKey) {
+        queryClient.refetchQueries({ queryKey });
+      } else {
+        queryClient.refetchQueries();
+      }
+      if (redirectPath === '/login') {
+        clearCookie();
+      }
+      handleNavigate(navigate, redirectPath, true);
+    }
+  };
+
+  useEffect(() => {
+    const handleModal = async () => {
+      if (error.status === 401) {
+        await handleError(
+          {
+            type: 'confirm',
+            text: '로그인',
+            message: '인증이 만료되었어요\n로그인 후 다시 시도해주세요',
+            displayCancel: false,
+          },
+          '/login',
+        );
+      } else {
+        await handleError(
+          {
+            type: 'confirm',
+            text: '확인',
+            message: error.response?.data.message || '예상치 못한 에러가 발생했어요.\n잠시 후 다시 시도해주세요',
+            displayCancel: false,
+          },
+          '/',
+        );
+      }
+    };
+
+    handleModal();
+  }, [error]);
+
+  return (
+    <div css={containerStyles}>
+      <ModalContainer />
+    </div>
+  );
+};
+
+export default ModalFallback;
+
+const containerStyles = (theme: Theme) => css`
+  width: 100%;
+  height: 100vh;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background-color: ${theme.colors.background.lightYellow};
+
+  ${mobileMediaQuery(css`
+    max-width: ${breakpoints.mobile};
+  `)}
+
+  ${pcMediaQuery(css`
+    max-width: ${breakpoints.pc};
+  `)}
+`;

--- a/src/components/common/ErrorBoundary/index.ts
+++ b/src/components/common/ErrorBoundary/index.ts
@@ -1,3 +1,5 @@
+import FallbackWrapper from '@/components/common/ErrorBoundary/FallbackWrapper';
+import ModalFallback from '@/components/common/ErrorBoundary/ModalFallback';
 import RootErrorFallback from '@/components/common/ErrorBoundary/RootErrorFallback';
 
-export { RootErrorFallback };
+export { FallbackWrapper, ModalFallback, RootErrorFallback };

--- a/src/components/common/Modal/ModalContents/ActionModal.tsx
+++ b/src/components/common/Modal/ModalContents/ActionModal.tsx
@@ -4,7 +4,7 @@ import { ActionModalContentProps } from '@/types';
 import { css, Theme } from '@emotion/react';
 
 const ActionModal = ({ onSubmit, onAbort, actionModal }: ActionModalContentProps) => (
-  <ModalTemplate isOverlay={true} onClose={onAbort} preventClick={false}>
+  <ModalTemplate isOverlay={true} onClose={onAbort} preventClick={true}>
     <ModalContent>
       <p css={descStyle}>{actionModal.message}</p>
       <ModalButtonGroup>

--- a/src/utils/handleNavigate.ts
+++ b/src/utils/handleNavigate.ts
@@ -1,0 +1,9 @@
+import { NavigateFunction } from 'react-router-dom';
+
+export const handleNavigate = (navigate: NavigateFunction, path: string | number, replace?: boolean) => {
+  if (typeof path === 'number') {
+    navigate(path);
+  } else {
+    navigate(path, { replace });
+  }
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,7 +2,16 @@ import { assert } from '@/utils/assert';
 import { getDaysInMonth } from '@/utils/getDaysInMonth';
 import { getPriority } from '@/utils/getPriority';
 import { handleKeyDown } from '@/utils/handleKeyDown';
+import { handleNavigate } from '@/utils/handleNavigate';
 import { optimisticUpdateMutateHandler } from '@/utils/optimisticUpdateMutateHandler';
 import { StatusError } from '@/utils/statusError';
 
-export { assert, getDaysInMonth, getPriority, handleKeyDown, optimisticUpdateMutateHandler, StatusError };
+export {
+  assert,
+  getDaysInMonth,
+  getPriority,
+  handleKeyDown,
+  handleNavigate,
+  optimisticUpdateMutateHandler,
+  StatusError,
+};


### PR DESCRIPTION
## 작업 사항
- 최상위 `App` 컴포넌트에 `Suspense` 추가
- 사용자 응답 처리를 위해 액션 모달의 백그라운드 클릭 방지 설정
- 에러 Fallback UI에 리액트 쿼리 초기화 로직 추가
- 에러를 모달로 안내할 수 있는 `ModalFallback` 컴포넌트 구현
   - `router` 재설정
   - 중복 제거를 위한 `Wrapper` 컴포넌트 및 `handleNavigate` 유틸 함수 추가

## 관련 이슈
close #157 #171 