### PR TITLE
Fix: 에러바운더리 fallback UI 내 쿼리 초기화 로직 수정

### DIFF
--- a/src/components/common/ErrorBoundary/FallbackWrapper.tsx
+++ b/src/components/common/ErrorBoundary/FallbackWrapper.tsx
@@ -1,15 +1,20 @@
 import { ModalFallback } from '@/components/common/ErrorBoundary';
 import { Loading } from '@/components/common/Loading';
 import { MainLayout } from '@/components/layouts';
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 import { PropsWithChildren, Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
-const FallbackWrapper = ({ children }: PropsWithChildren) => (
-  <ErrorBoundary FallbackComponent={ModalFallback}>
-    <Suspense fallback={<Loading />}>
-      <MainLayout>{children}</MainLayout>
-    </Suspense>
-  </ErrorBoundary>
-);
+const FallbackWrapper = ({ children }: PropsWithChildren) => {
+  const { reset } = useQueryErrorResetBoundary();
+
+  return (
+    <ErrorBoundary FallbackComponent={ModalFallback} onReset={reset}>
+      <Suspense fallback={<Loading />}>
+        <MainLayout>{children}</MainLayout>
+      </Suspense>
+    </ErrorBoundary>
+  );
+};
 
 export default FallbackWrapper;

--- a/src/components/common/ErrorBoundary/ModalFallback.tsx
+++ b/src/components/common/ErrorBoundary/ModalFallback.tsx
@@ -26,9 +26,9 @@ const ModalFallback = ({ error, resetErrorBoundary, queryKey }: Props) => {
     if (res.ok) {
       resetErrorBoundary();
       if (queryKey) {
-        queryClient.refetchQueries({ queryKey });
+        queryClient.resetQueries({ queryKey });
       } else {
-        queryClient.refetchQueries();
+        queryClient.resetQueries();
       }
       if (redirectPath === '/login') {
         clearCookie();


### PR DESCRIPTION
## 작업 사항
- `refetchQueries`에서 `resetQueries`로 변경
- `ModalFallback` 컴포넌트의 에러바운더리에 `onReset` 추가

## 관련 이슈
close #173 