### PR TITLE
Refactor: 리스트 웹 접근성 개선

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -25,13 +25,6 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'jsx-a11y/anchor-is-valid': ['warn', { components: ['Link'], specialLink: ['to'] }],
     'jsx-a11y/label-has-associated-control': ['error', { assert: 'either' }],
-    'jsx-a11y/no-noninteractive-element-to-interactive-role': [
-      'error',
-      {
-        ul: ['button'],
-        li: ['button'],
-      },
-    ],
     'jsx-a11y/no-autofocus': 'off',
     'react/prop-types': 'off',
   },

--- a/src/Pages/InvitePage.tsx
+++ b/src/Pages/InvitePage.tsx
@@ -76,11 +76,12 @@ const InvitePage = () => {
               setIsSelected(!isSelected);
             }
           }}
+          aria-label={searchResult.name}
           tabIndex={0}
           role="button"
         >
           <IconWrapper
-            aria-label={isSelected ? 'Selected member' : 'Unselected member'}
+            aria-label={isSelected ? '선택된 멤버' : '선택되지 않은 멤버'}
             aria-checked={isSelected}
             role="checkbox"
             css={[checkIconStyle, isSelected && checkedStyle, isSelected && customCheckedStyle]}

--- a/src/Pages/LoginPage.tsx
+++ b/src/Pages/LoginPage.tsx
@@ -55,7 +55,7 @@ const LoginPage = () => {
     <div>
       <div css={loginContainer}>
         <img css={loginHomeImgStyle} src="/images/login.png" alt="login_image" />
-        <button onClick={handleGoogleLogin} aria-label="Login with Google">
+        <button onClick={handleGoogleLogin} aria-label="구글 계정으로 로그인">
           <img css={googleLoginImgStyle} src="/images/google_login.png" alt="google_login" />
         </button>
         <button css={demoUserStyle} onClick={handleTempLogin}>

--- a/src/Pages/SquadPage.tsx
+++ b/src/Pages/SquadPage.tsx
@@ -3,8 +3,8 @@ import { useCreateSquad } from '@/hooks/mutations';
 import { squadQueryOptions } from '@/hooks/queries';
 import { useToastStore } from '@/stores';
 import { breakpoints, mobileMediaQuery, pcMediaQuery } from '@/styles/breakpoints';
+import { fullSizeButtonStyle } from '@/styles/globalStyles';
 import { Squad } from '@/types/squad';
-import { handleKeyDown } from '@/utils';
 import { css, Theme } from '@emotion/react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { startTransition } from 'react';
@@ -52,14 +52,10 @@ const SquadItem = ({ squad }: { squad: Squad }) => {
   };
 
   return (
-    <li
-      css={itemStyle}
-      onClick={handleNavigation}
-      onKeyDown={(e) => handleKeyDown(e, handleNavigation)}
-      tabIndex={0}
-      role="button"
-    >
-      {squad.squadName}
+    <li css={itemStyle}>
+      <button onClick={handleNavigation} style={fullSizeButtonStyle} aria-label={`${squad.squadName} 스쿼드 선택`}>
+        {squad.squadName}
+      </button>
     </li>
   );
 };
@@ -69,7 +65,6 @@ const itemStyle = (theme: Theme) => css`
   justify-content: center;
   align-items: center;
   height: 52px;
-  padding: 12px;
   margin: 8px 16px;
   border-radius: 8px;
   background-color: ${theme.colors.background.lightYellow};
@@ -78,14 +73,18 @@ const itemStyle = (theme: Theme) => css`
 
   ${mobileMediaQuery(css`
     max-width: ${breakpoints.mobile};
-    ${theme.typography.size_16}
+    font-size: ${theme.typography.size_16};
   `)}
 
   ${pcMediaQuery(css`
     max-width: ${breakpoints.pc};
-    ${theme.typography.size_24}
+    font-size: ${theme.typography.size_24};
     font-weight: 500;
   `)}
+
+  & button {
+    font-size: ${theme.typography.size_16};
+  }
 `;
 
 const headerStyle = (theme: Theme) => css`
@@ -95,13 +94,13 @@ const headerStyle = (theme: Theme) => css`
   margin: 24px 16px;
 
   & span {
-    font-size: ${theme.typography.size_24};
+    ${theme.typography.size_24};
     padding-left: 16px;
   }
 
   & button {
     width: 112px;
-    font-size: ${theme.typography.size_16};
+    ${theme.typography.size_16};
     background-color: var(--color-primary);
     color: white;
   }

--- a/src/components/Member/MemberTodoItem.tsx
+++ b/src/components/Member/MemberTodoItem.tsx
@@ -12,7 +12,7 @@ const MemberTodoItem = ({ todo }: { todo: ToDoDetail }) => {
     <li css={[todoItemStyle(), getStatusStyles(isCompleted, theme), memberTodoItemStyle]}>
       <div css={contentStyle}>
         <IconWrapper
-          aria-label={isCompleted ? 'Completed todo' : 'Uncompleted todo'}
+          aria-label={isCompleted ? '완료' : '미완료'}
           aria-checked={isCompleted}
           role="checkbox"
           css={[checkIconStyle, isCompleted && checkedStyle]}

--- a/src/components/Member/SelectMemberList.tsx
+++ b/src/components/Member/SelectMemberList.tsx
@@ -8,8 +8,8 @@ import { MEMBER_STYLE_TYPE } from '@/constants/squad';
 import { useModal } from '@/hooks';
 import { squadDetailQueryOptions, squadKeys } from '@/hooks/queries';
 import { useToastStore } from '@/stores';
+import { fullSizeButtonStyle } from '@/styles/globalStyles';
 import { SquadMember } from '@/types';
-import { handleKeyDown } from '@/utils';
 import { css, Theme } from '@emotion/react';
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { useState } from 'react';
@@ -72,22 +72,18 @@ const Member = ({ squadId, member }: { squadId: number; member: SquadMember }) =
 
   return (
     <>
-      <li
-        css={itemStyle}
-        onClick={handleSelectMember}
-        onKeyDown={(e) => handleKeyDown(e, handleSelectMember)}
-        tabIndex={0}
-        role="button"
-      >
-        <MemberProfile member={member} displayRole={false} type={MEMBER_STYLE_TYPE.DEFAULT} />
-        <IconWrapper
-          aria-label={isChecked ? 'Selected member' : 'Unselected member'}
-          aria-checked={isChecked}
-          role="checkbox"
-          css={[checkIconStyle, isChecked && checkedStyle]}
-        >
-          {isChecked && <Check />}
-        </IconWrapper>
+      <li css={itemStyle}>
+        <button onClick={handleSelectMember} style={fullSizeButtonStyle} aria-label={member.name}>
+          <MemberProfile member={member} displayRole={false} type={MEMBER_STYLE_TYPE.DEFAULT} />
+          <IconWrapper
+            aria-label={isChecked ? '선택된 멤버' : '선택되지 않은 멤버'}
+            aria-checked={isChecked}
+            role="checkbox"
+            css={[checkIconStyle, isChecked && checkedStyle]}
+          >
+            {isChecked && <Check />}
+          </IconWrapper>
+        </button>
       </li>
       <AssignSquadLeaderModal />
     </>

--- a/src/components/Member/SidebarMemberList.tsx
+++ b/src/components/Member/SidebarMemberList.tsx
@@ -57,7 +57,7 @@ const Member = ({ member, showIcon }: { member: SquadMember; showIcon: boolean }
         <MemberProfile member={member} displayRole type={MEMBER_STYLE_TYPE.DEFAULT} />
         {showIcon && (
           <IconWrapper
-            aria-label="Remove member from squad"
+            aria-label={`${member.name} 강퇴`}
             onClick={handleRemoveUser}
             role="button"
             css={commonButtonStyle}

--- a/src/components/Member/SquadDetailMemberList.tsx
+++ b/src/components/Member/SquadDetailMemberList.tsx
@@ -2,7 +2,7 @@ import { MemberProfile } from '@/components/Member';
 import { MEMBER_STYLE_TYPE } from '@/constants/squad';
 import { useUserCookie } from '@/hooks';
 import { useMemberStore } from '@/stores';
-import { scrollBarStyle } from '@/styles/globalStyles';
+import { fullSizeButtonStyle, scrollBarStyle } from '@/styles/globalStyles';
 import { SquadMember } from '@/types';
 import { css } from '@emotion/react';
 
@@ -28,23 +28,15 @@ export default SquadDetailMemberList;
 const Member = ({ member }: { member: SquadMember }) => {
   const { selectedMember, setSelectedMember } = useMemberStore((state) => state);
   return (
-    <li
-      onClick={() => setSelectedMember(member)}
-      css={memberStyle}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter') {
-          setSelectedMember(member);
-        }
-      }}
-      tabIndex={0}
-      role="button"
-    >
-      <MemberProfile
-        member={member}
-        selectedMember={selectedMember}
-        displayRole={false}
-        type={MEMBER_STYLE_TYPE.SQUAD_DETIAL}
-      />
+    <li css={memberStyle}>
+      <button onClick={() => setSelectedMember(member)} style={fullSizeButtonStyle} aria-label={selectedMember?.name}>
+        <MemberProfile
+          member={member}
+          selectedMember={selectedMember}
+          displayRole={false}
+          type={MEMBER_STYLE_TYPE.SQUAD_DETIAL}
+        />
+      </button>
     </li>
   );
 };

--- a/src/components/Todo/TodoList.tsx
+++ b/src/components/Todo/TodoList.tsx
@@ -7,8 +7,8 @@ import { useInfinite, useToastHandler } from '@/hooks';
 import { useDeleteTodo, useUpdateTodo } from '@/hooks/mutations';
 import { todoKeys } from '@/hooks/queries';
 import { useDayStore, useSquadStore } from '@/stores';
+import { fullSizeButtonStyle } from '@/styles/globalStyles';
 import { ToDoDetail, TodoQueryParams, UpdateTodoRequest } from '@/types';
-import { handleKeyDown } from '@/utils';
 import { css, keyframes, Theme, useTheme } from '@emotion/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { KeyboardEvent, useState } from 'react';
@@ -33,8 +33,12 @@ export const TodoList = ({ todos, loadMoreTodos, hasNextPage, isMeSelected, squa
           <MemberTodoItem key={todo.toDoId} todo={todo} />
         ),
       )}
-      <br />
-      <div ref={loadMoreRef} />
+      {todos.length > 0 && (
+        <>
+          <br />
+          <div ref={loadMoreRef} />
+        </>
+      )}
     </ul>
   );
 };
@@ -95,6 +99,10 @@ const TodoItem = ({ todo, squadMemberId }: { todo: ToDoDetail; squadMemberId: nu
   };
 
   const handleEditContents = () => {
+    if (contents === newContents) {
+      setIsEditMode(false);
+      return;
+    }
     const newTodo: UpdateTodoRequest = {
       toDoAt: selectedDay,
       toDoStatus,
@@ -114,63 +122,44 @@ const TodoItem = ({ todo, squadMemberId }: { todo: ToDoDetail; squadMemberId: nu
   return (
     <>
       {!isDeleteMode ? (
-        <li
-          css={[todoItemStyle(), getStatusStyles(isCompleted, theme)]}
-          onClick={() => toggleTodoStatus()}
-          onKeyDown={(e) => {
-            if (!isEditMode) {
-              handleKeyDown(e, toggleTodoStatus);
-            }
-          }}
-          tabIndex={0}
-          role="button"
-        >
-          <div css={contentStyle}>
-            <IconWrapper
-              aria-label={isCompleted ? 'Completed todo' : 'Uncompleted todo'}
-              aria-checked={isCompleted}
-              role="checkbox"
-              css={[checkIconStyle, isCompleted && checkedStyle]}
-            >
-              {isCompleted && <Check />}
-            </IconWrapper>
-            {!isEditMode ? (
-              <p>{contents}</p>
-            ) : (
-              <input
-                type="text"
-                value={newContents}
-                onChange={(e) => setNewContents(e.target.value)}
-                onClick={(e) => e.stopPropagation()}
-                onKeyUp={handleKeyPressForEdit}
-                autoFocus
-                css={editInputStyle}
-              />
-            )}
-          </div>
-          {!isEditMode && (
-            <div
-              css={actionStyle}
-              onClick={(e) => e.stopPropagation()}
-              // onKeyDown={(e) => e.stopPropagation()}
-              role="presentation"
-            >
-              <IconWrapper onClick={() => setIsEditMode(true)}>
+        <li css={[todoItemStyle(), getStatusStyles(isCompleted, theme)]}>
+          <button onClick={toggleTodoStatus} style={fullSizeButtonStyle} aria-label="투두 상태 변경">
+            <div css={contentStyle}>
+              <IconWrapper
+                aria-label={isCompleted ? '완료된 투두' : '완료되지 않은 투두'}
+                aria-checked={isCompleted}
+                role="checkbox"
+                css={[checkIconStyle, isCompleted && checkedStyle]}
+              >
+                {isCompleted && <Check />}
+              </IconWrapper>
+              {!isEditMode ? (
+                <p>{contents}</p>
+              ) : (
+                <input
+                  type="text"
+                  value={newContents}
+                  onChange={(e) => setNewContents(e.target.value)}
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={handleKeyPressForEdit}
+                  css={editInputStyle}
+                  autoFocus
+                />
+              )}
+            </div>
+          </button>
+          {!isEditMode ? (
+            <div css={actionStyle} role="presentation">
+              <IconWrapper onClick={() => setIsEditMode(true)} aria-label="투두 수정">
                 <Edit />
               </IconWrapper>
-              <IconWrapper onClick={handleDeleteTodo}>
+              <IconWrapper onClick={handleDeleteTodo} aria-label="투두 삭제">
                 <Delete />
               </IconWrapper>
             </div>
-          )}
-          {isEditMode && (
-            <div
-              css={editActionStyle}
-              onClick={(e) => e.stopPropagation()}
-              // onKeyDown={(e) => e.stopPropagation()}
-              role="presentation"
-            >
-              <Button id="edit-btn" text="수정" variant="confirm" onClick={handleEditContents} />
+          ) : (
+            <div css={editActionStyle} role="presentation">
+              <Button id="edit-btn" text="수정" variant="confirm" onClick={handleEditContents} aria-label="수정하기" />
               <Button
                 text="취소"
                 variant="default"
@@ -178,26 +167,18 @@ const TodoItem = ({ todo, squadMemberId }: { todo: ToDoDetail; squadMemberId: nu
                   setNewContents(contents);
                   setIsEditMode(false);
                 }}
+                aria-label="투두 수정 취소"
               />
             </div>
           )}
         </li>
       ) : (
-        <li
-          css={todoItemStyle(isDeleteMode)}
-          onClick={handleConfirmDelete}
-          onKeyDown={(e) => handleKeyDown(e, handleConfirmDelete)}
-          tabIndex={0}
-          role="button"
-        >
-          <p>등록된 할일을 삭제할까요?</p>
-          <IconWrapper style={{ marginRight: '8px' }}>
-            <Close
-              onClick={(e) => {
-                e.stopPropagation();
-                setIsDeleteMode(false);
-              }}
-            />
+        <li css={todoItemStyle(isDeleteMode)}>
+          <button onClick={handleConfirmDelete} style={fullSizeButtonStyle} aria-label="삭제하기" tabIndex={0}>
+            등록된 할일을 삭제할까요?
+          </button>
+          <IconWrapper style={{ marginRight: '8px' }} onClick={() => setIsDeleteMode(false)} aria-label="삭제 취소">
+            <Close />
           </IconWrapper>
         </li>
       )}

--- a/src/components/common/Calendar/Calendar.tsx
+++ b/src/components/common/Calendar/Calendar.tsx
@@ -1,6 +1,6 @@
 import { useDayStore } from '@/stores';
 import { breakpoints, mobileMediaQuery, pcMediaQuery } from '@/styles/breakpoints';
-import { scrollBarStyle } from '@/styles/globalStyles';
+import { fullSizeButtonStyle, scrollBarStyle } from '@/styles/globalStyles';
 import { getDaysInMonth } from '@/utils';
 import { css, Theme, useTheme } from '@emotion/react';
 import { addMonths, format, subMonths } from 'date-fns';
@@ -92,11 +92,24 @@ const CalendarList = ({ currentMonth }: { currentMonth: Date }) => {
   }, [selectedDay]);
 
   return (
-    <ul css={calendarStyle} ref={daysContainerRef} onClick={handleClick} onKeyDown={handleKeyDown} role="button">
-      {daysInCurrentMonth.map((day) => (
-        <Calendar.Item key={day} day={day} ref={day === selectedDay ? selectedDayRef : null} />
-      ))}
-    </ul>
+    <>
+      {daysInCurrentMonth.length > 0 && (
+        <ul
+          css={calendarStyle}
+          ref={daysContainerRef}
+          onClick={handleClick}
+          onKeyDown={handleKeyDown}
+          tabIndex={0}
+          role="listbox"
+          aria-label="날짜 선택"
+          aria-activedescendant={selectedDay ? `${selectedDay}일` : undefined}
+        >
+          {daysInCurrentMonth.map((day) => (
+            <Calendar.Item key={day} day={day} ref={day === selectedDay ? selectedDayRef : null} />
+          ))}
+        </ul>
+      )}
+    </>
   );
 };
 
@@ -115,9 +128,14 @@ Calendar.Item = forwardRef<HTMLLIElement, { day: string }>(({ day }, ref) => {
       ]}
       data-day={day}
       ref={ref}
+      role="option"
+      aria-selected={selectedDay === day}
+      id={`${day}일`}
     >
-      <span>{format(new Date(day), 'dd')}</span>
-      <span css={dayNameStyle}>{format(new Date(day), 'EEE', { locale: ko })}</span>
+      <button style={fullSizeButtonStyle} aria-label={`${day}일`}>
+        <span>{format(new Date(day), 'dd')}</span>
+        <span css={dayNameStyle}>{format(new Date(day), 'EEE', { locale: ko })}</span>
+      </button>
     </li>
   );
 });
@@ -164,7 +182,10 @@ const todayStyle = (theme: Theme, isSelected: boolean) => css`
 const selectedDateStyle = (theme: Theme) => css`
   background-color: ${theme.colors.primary};
   border: 2px solid ${theme.colors.primary};
-  color: white;
+
+  & button {
+    color: #1b1b52;
+  }
 `;
 
 const dayNameStyle = (theme: Theme) => css`

--- a/src/components/common/Form/Form.tsx
+++ b/src/components/common/Form/Form.tsx
@@ -18,6 +18,7 @@ const Form = ({ type, onSubmit, onKeyDown, value, onChange, placeholder, style }
     <input type={type} value={value} onChange={onChange} autoFocus placeholder={placeholder} />
     <IconWrapper
       css={addIconStyle}
+      aria-label="할일 등록"
       onClick={() => {
         // Button 태그로 인식하기 위함
       }}

--- a/src/components/common/Header/HeaderTemplate.tsx
+++ b/src/components/common/Header/HeaderTemplate.tsx
@@ -16,7 +16,7 @@ const BackButton = () => {
 
   return (
     <div css={leftMenu}>
-      <IconWrapper aria-label="Go to back" role="button" onClick={handleBack} disabled={location.pathname === '/'}>
+      <IconWrapper aria-label="뒤로가기" role="button" onClick={handleBack} disabled={location.pathname === '/'}>
         <Back />
       </IconWrapper>
       {location.pathname === '/' && <img css={logoStyle} src="./images/logo.png" alt="logo" />}
@@ -30,7 +30,7 @@ const ToggleThemeButton = () => {
   const { isDarkMode, toggleTheme } = useThemeStore((state) => state);
 
   return (
-    <IconWrapper aria-label="Toggle theme" onClick={toggleTheme} role="button">
+    <IconWrapper aria-label="테마 변경" onClick={toggleTheme} role="button">
       {isDarkMode ? <Light /> : <Dark />}
     </IconWrapper>
   );
@@ -42,7 +42,7 @@ const NotificationsButton = () => {
 
   return (
     <>
-      <IconWrapper aria-label="alarm" onClick={() => toggleOpen()} role="button">
+      <IconWrapper aria-label="알림 조회" onClick={() => toggleOpen()} role="button">
         {hasUnreadMessages ? <ActiveBell /> : <Bell />}
       </IconWrapper>
       {isOpen && <Notification toggleOpen={toggleOpen} />}
@@ -51,13 +51,7 @@ const NotificationsButton = () => {
 };
 
 const SidebarToggleButton = ({ toggleSidebar }: { toggleSidebar: VoidFunction }) => (
-  <IconWrapper
-    aria-label="menu"
-    onClick={() => {
-      toggleSidebar();
-    }}
-    role="button"
-  >
+  <IconWrapper aria-label="더보기 메뉴" onClick={() => toggleSidebar()} role="button">
     <Menu />
   </IconWrapper>
 );

--- a/src/components/common/Sidebar/Sidebar.tsx
+++ b/src/components/common/Sidebar/Sidebar.tsx
@@ -7,7 +7,8 @@ import { useUserCookie } from '@/hooks';
 import { useDeleteSquad, useExitSquad, useUpdateSquadName } from '@/hooks/mutations';
 import { squadDetailQueryOptions, squadKeys } from '@/hooks/queries';
 import { useSquadStore, useToastStore } from '@/stores';
-import { getPriority, handleKeyDown } from '@/utils';
+import { fullSizeButtonStyle } from '@/styles/globalStyles';
+import { getPriority } from '@/utils';
 import { css, Theme } from '@emotion/react';
 import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
@@ -79,16 +80,16 @@ export const Sidebar = ({ closeSidebar }: { closeSidebar: VoidFunction }) => {
       <dialog css={sidebarContainer}>
         <header css={headerStyle}>
           <h1>스쿼드 관리</h1>
-          <IconWrapper aria-label="Close sidebar" onClick={closeSidebar} role="button" css={commonButtonStyle}>
+          <IconWrapper aria-label="사이드바 닫기" onClick={closeSidebar} role="button" css={commonButtonStyle}>
             <Close />
           </IconWrapper>
         </header>
-        <section css={squadInfoStyle} aria-labelledby="squad-detail">
+        <section css={squadInfoStyle}>
           <h2 id="squad-detail">스쿼드명</h2>
           <div>
             <h3>{squadName}</h3>
             <IconWrapper
-              aria-label="Edit squad name"
+              aria-label="스쿼드명 수정"
               onClick={handleUpdateSquadName}
               role="button"
               css={commonButtonStyle}
@@ -98,39 +99,30 @@ export const Sidebar = ({ closeSidebar }: { closeSidebar: VoidFunction }) => {
             </IconWrapper>
           </div>
         </section>
-        <section css={membersStyle} aria-labelledby="squad-members">
+        <section css={membersStyle}>
           <h2 id="squad-members">멤버</h2>
           <SidebarMemberList members={squadMembers} myRole={squadDetail.mySquadMemberRole} />
         </section>
-        <section css={settingsStyle} aria-labelledby="squad-settings">
+        <section css={settingsStyle}>
           <h2 id="squad-settings">설정</h2>
           <ul>
-            <li
-              onClick={handleInvitation}
-              onKeyDown={(e) => handleKeyDown(e, handleInvitation)}
-              tabIndex={0}
-              role="button"
-            >
-              멤버 초대
+            <li>
+              <button onClick={handleInvitation} style={fullSizeButtonStyle} aria-label="멤버 초대">
+                멤버 초대
+              </button>
             </li>
             {isLeader && (
-              <li
-                onClick={handleAssignLeader}
-                onKeyDown={(e) => handleKeyDown(e, handleAssignLeader)}
-                tabIndex={0}
-                role="button"
-              >
-                리더 변경
+              <li>
+                <button onClick={handleAssignLeader} style={fullSizeButtonStyle} aria-label="리더 변경">
+                  리더 변경
+                </button>
               </li>
             )}
             {isLeader && (
-              <li
-                onClick={handleSquadDelete}
-                onKeyDown={(e) => handleKeyDown(e, handleSquadDelete)}
-                tabIndex={0}
-                role="button"
-              >
-                스쿼드 삭제
+              <li>
+                <button onClick={handleSquadDelete} style={fullSizeButtonStyle} aria-label="스쿼드 삭제">
+                  스쿼드 삭제
+                </button>
               </li>
             )}
           </ul>
@@ -219,7 +211,7 @@ const membersStyle = css`
   }
 `;
 
-const settingsStyle = css`
+const settingsStyle = (theme: Theme) => css`
   padding: 0 16px;
   flex: 1;
   margin-bottom: 24px;
@@ -235,6 +227,11 @@ const settingsStyle = css`
 
   & li:hover {
     opacity: 0.5;
+  }
+
+  & button {
+    text-align: left;
+    font-size: ${theme.typography.size_16};
   }
 `;
 

--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -41,7 +41,7 @@ const Toast = ({ message, type, onRemove, showCloseButton }: Omit<Toast, 'id'> &
     <IconWrapper
       customStyle={() => closeButton(showCloseButton)}
       onClick={onRemove}
-      aria-label="Close toast"
+      aria-label="토스트 닫기"
       role="button"
     >
       <Close />

--- a/src/components/layouts/Footer.tsx
+++ b/src/components/layouts/Footer.tsx
@@ -5,18 +5,18 @@ import { Link } from 'react-router-dom';
 
 const Footer = () => (
   <footer css={footerContainer}>
-    <Link to="/squads" css={menuIcon} aria-label="Go to squads">
+    <Link to="/squads" css={menuIcon} aria-label="스쿼드 목록">
       <IconWrapper>
         <Target />
       </IconWrapper>
       <span>스쿼드</span>
     </Link>
-    <Link to="/" css={homeIcon} aria-label="Go to home">
+    <Link to="/" css={homeIcon} aria-label="홈">
       <IconWrapper>
         <Pouch />
       </IconWrapper>
     </Link>
-    <Link to="/me" css={menuIcon} aria-label="Go to my">
+    <Link to="/me" css={menuIcon} aria-label="마이 페이지">
       <IconWrapper>
         <User />
       </IconWrapper>

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -184,6 +184,7 @@ export const globalStyles = (theme: Theme) => css`
     border-spacing: 0;
   }
   button {
+    color: ${theme.colors.text};
     border-style: none;
     background-color: transparent;
     cursor: pointer;
@@ -231,3 +232,5 @@ export const scrollBarStyle = css`
     scrollbar-color: rgba(212, 212, 212, 0.7) transparent;
   }
 `;
+
+export const fullSizeButtonStyle = { width: '100%', height: '100%' };


### PR DESCRIPTION
## 작업 사항
- a11y의 `ul`, `li` 규칙 제거
- `li` 내부 요소를 `button` 태그로 변경하고 aria-label 적용
- Calendar 컴포넌트
   - 이벤트 위임을 위한 role 및 속성 추가
- 렌더링 되는 `li` 요소가 없을 경우 `ul` 태그 렌더링 방지

### 성능 개선
- 개선 전 성능: Lighthouse Accessibility `79점`
- 개선 후 성능: Lighthouse Accessibility `100점`

<img width="850" alt="79" src="https://github.com/user-attachments/assets/bb0a453c-2fbf-46ae-928d-158ced84e845" />
<img width="838" alt="88" src="https://github.com/user-attachments/assets/6a221616-eb1a-4569-8fa9-32e810bcd09f" />
<img width="836" alt="97" src="https://github.com/user-attachments/assets/cc78ba17-8b55-4d6e-81a7-2aabbdb695ed" />
<img width="846" alt="100" src="https://github.com/user-attachments/assets/cb8b5577-b0dd-4328-8643-edc29bd7ea55" />

## 관련 이슈
close #179 