### PR TITLE
Refactor: 알림 읽음 및 수락 로직 개선

### DIFF
--- a/src/hooks/mutations/useAcceptInvitation.tsx
+++ b/src/hooks/mutations/useAcceptInvitation.tsx
@@ -3,8 +3,8 @@ import { AcceptSquadInvitationParams, MutateOptionsType } from '@/hooks/mutation
 import { ApiResponse } from '@/types';
 import { useMutation } from '@tanstack/react-query';
 
-const useAcceptInvitation = (options: MutateOptionsType<ApiResponse<null>, AcceptSquadInvitationParams>) => {
-  const { mutate: acceptInvitation } = useMutation({
+const useAcceptInvitation = (options?: MutateOptionsType<ApiResponse<null>, AcceptSquadInvitationParams>) => {
+  const { mutateAsync: acceptInvitation } = useMutation({
     mutationFn: acceptSquadInvite,
     ...options,
   });


### PR DESCRIPTION
## 작업 사항
- 알림 수락을 위한 `mutate` 함수를 `mutateAsync`로 변경하여 비동기 처리 개선
   - `onSuccess`에서 처리하던 로직을 try ~ catch로 변경
- 알림 목록 웹 접근성 개선
- 깨진 스타일 복구

## 관련 이슈
close #184 