### PR TITLE
Refactor: 모바일 우선 방식으로 반응형 로직 개선

### DIFF
--- a/src/Pages/SquadDetailPage.tsx
+++ b/src/Pages/SquadDetailPage.tsx
@@ -5,7 +5,7 @@ import { TODO_PAGE_SIZE, TODO_STATUS } from '@/constants/todo';
 import { useUserCookie } from '@/hooks';
 import { squadDetailQueryOptions, todoInfiniteQueryOptions } from '@/hooks/queries';
 import { useDayStore, useMemberStore, useSquadStore } from '@/stores';
-import { mobileMediaQuery, pcMediaQuery } from '@/styles/breakpoints';
+import { pcMediaQuery } from '@/styles/breakpoints';
 import { css, Theme } from '@emotion/react';
 import { useInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
@@ -117,10 +117,8 @@ const headerStyle = (theme: Theme) => css`
   justify-content: space-between;
   align-items: center;
   margin: 24px 24px 12px 32px;
-
-  ${mobileMediaQuery(css`
-    ${theme.typography.size_14}
-  `)}
+  ${theme.typography.size_14}
+  font-weight: 500;
 
   ${pcMediaQuery(css`
     ${theme.typography.size_16}

--- a/src/Pages/SquadPage.tsx
+++ b/src/Pages/SquadPage.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/common';
 import { useCreateSquad } from '@/hooks/mutations';
 import { squadQueryOptions } from '@/hooks/queries';
 import { useToastStore } from '@/stores';
-import { breakpoints, mobileMediaQuery, pcMediaQuery } from '@/styles/breakpoints';
+import { breakpoints, pcMediaQuery } from '@/styles/breakpoints';
 import { fullSizeButtonStyle } from '@/styles/globalStyles';
 import { Squad } from '@/types/squad';
 import { css, Theme } from '@emotion/react';
@@ -70,16 +70,10 @@ const itemStyle = (theme: Theme) => css`
   background-color: ${theme.colors.background.lightYellow};
   box-shadow: 0px 3px 28px 0px rgba(37, 37, 37, 0.05);
   cursor: pointer;
-
-  ${mobileMediaQuery(css`
-    max-width: ${breakpoints.mobile};
-    ${theme.typography.size_16}
-  `)}
+  max-width: ${breakpoints.mobile};
 
   ${pcMediaQuery(css`
     max-width: ${breakpoints.pc};
-    ${theme.typography.size_24}
-    font-weight: 500;
   `)}
 
   & button {

--- a/src/components/Member/SidebarMemberList.tsx
+++ b/src/components/Member/SidebarMemberList.tsx
@@ -7,7 +7,7 @@ import { MEMBER_STYLE_TYPE } from '@/constants/squad';
 import { useRemoveUserFromSquad } from '@/hooks/mutations';
 import { squadKeys } from '@/hooks/queries';
 import { useSquadStore, useToastStore } from '@/stores';
-import { mobileMediaQuery, pcMediaQuery } from '@/styles/breakpoints';
+import { pcMediaQuery } from '@/styles/breakpoints';
 import { SquadMember } from '@/types';
 import { css } from '@emotion/react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -73,9 +73,7 @@ const Member = ({ member, showIcon }: { member: SquadMember; showIcon: boolean }
 
 const containerStyle = css`
   overflow-y: auto;
-  ${mobileMediaQuery(css`
-    height: 180px;
-  `)}
+  height: 180px;
 
   ${pcMediaQuery(css`
     height: 260px;

--- a/src/components/common/Calendar/Calendar.tsx
+++ b/src/components/common/Calendar/Calendar.tsx
@@ -1,5 +1,5 @@
 import { useDayStore } from '@/stores';
-import { breakpoints, mobileMediaQuery, pcMediaQuery } from '@/styles/breakpoints';
+import { breakpoints, pcMediaQuery } from '@/styles/breakpoints';
 import { fullSizeButtonStyle, scrollBarStyle } from '@/styles/globalStyles';
 import { getDaysInMonth } from '@/utils';
 import { css, Theme, useTheme } from '@emotion/react';
@@ -197,6 +197,8 @@ const monthNavButtonStyle = (theme: Theme) => css`
   display: flex;
   justify-content: center;
   align-items: center;
+  max-width: ${breakpoints.mobile};
+  margin: 8px auto;
 
   & span {
     display: flex;
@@ -225,10 +227,6 @@ const monthNavButtonStyle = (theme: Theme) => css`
       background-color: #eeeeee70;
     }
   }
-  ${mobileMediaQuery(css`
-    max-width: ${breakpoints.mobile};
-    margin: 8px 36px;
-  `)}
 
   ${pcMediaQuery(css`
     max-width: ${breakpoints.pc};

--- a/src/components/common/ErrorBoundary/ModalFallback.tsx
+++ b/src/components/common/ErrorBoundary/ModalFallback.tsx
@@ -1,6 +1,6 @@
 import { ActionModal } from '@/components/common/Modal';
 import { useModal, useUserCookie } from '@/hooks';
-import { breakpoints, mobileMediaQuery, pcMediaQuery } from '@/styles/breakpoints';
+import { breakpoints, pcMediaQuery } from '@/styles/breakpoints';
 import { ActionModalType, ApiErrorResponse } from '@/types';
 import { handleNavigate } from '@/utils';
 import { css, Theme } from '@emotion/react';
@@ -82,10 +82,7 @@ const containerStyles = (theme: Theme) => css`
   flex-direction: column;
   justify-content: space-between;
   background-color: ${theme.colors.background.lightYellow};
-
-  ${mobileMediaQuery(css`
-    max-width: ${breakpoints.mobile};
-  `)}
+  max-width: ${breakpoints.mobile};
 
   ${pcMediaQuery(css`
     max-width: ${breakpoints.pc};

--- a/src/components/layouts/Container.tsx
+++ b/src/components/layouts/Container.tsx
@@ -1,5 +1,5 @@
 import { breakpoints } from '@/styles';
-import { mobileMediaQuery, pcMediaQuery } from '@/styles/breakpoints';
+import { pcMediaQuery } from '@/styles/breakpoints';
 import { css } from '@emotion/react';
 import { ReactNode } from 'react';
 
@@ -19,10 +19,7 @@ const containerStyles = css`
   flex-direction: column;
   justify-content: space-between;
   background-color: #fff;
-
-  ${mobileMediaQuery(css`
-    max-width: ${breakpoints.mobile};
-  `)}
+  max-width: ${breakpoints.mobile};
 
   ${pcMediaQuery(css`
     max-width: ${breakpoints.pc};

--- a/src/context/modal/provider.tsx
+++ b/src/context/modal/provider.tsx
@@ -1,5 +1,4 @@
 import { modalContext } from '@/context/modal/context';
-import { breakpoints, mobileMediaQuery, pcMediaQuery } from '@/styles/breakpoints';
 import { ModalParameters, ModalType } from '@/types';
 import { css } from '@emotion/react';
 import { PropsWithChildren, useCallback, useMemo, useRef, useState } from 'react';
@@ -34,12 +33,4 @@ const modalConatiner = css`
   position: relative;
   margin: 0 auto;
   overflow: hidden;
-
-  ${mobileMediaQuery(css`
-    max-width: ${breakpoints.mobile};
-  `)}
-
-  ${pcMediaQuery(css`
-    max-width: ${breakpoints.pc};
-  `)}
 `;

--- a/src/styles/breakpoints.ts
+++ b/src/styles/breakpoints.ts
@@ -6,7 +6,7 @@ export const breakpoints = {
 };
 
 export const mobileMediaQuery = (styles: SerializedStyles) => css`
-  @media (min-width: ${breakpoints.mobile}) {
+  @media (max-width: ${breakpoints.mobile}) {
     ${styles}
   }
 `;


### PR DESCRIPTION
## 작업 사항
- `mobileMediaQuery`의 `min-width`를 `max-width`로 변경
   - 모바일 해상도 로직을 기본 스타일로 지정

## 관련 이슈
close #189 