### PR TITLE
Refactor: 스쿼드 상세 페이지 멤버 프로필 이미지 사이즈 조정

### DIFF
--- a/src/components/Member/MemberProfile.tsx
+++ b/src/components/Member/MemberProfile.tsx
@@ -22,7 +22,7 @@ const MemberProfile = ({ member, selectedMember, displayRole, type }: Props) => 
   return (
     <div css={infoStyle}>
       {isSquadDetail && (
-        <div css={activeMember?.name === name ? activeStyle : inactiveStyle}>
+        <div css={[imgContainerStyle, activeMember?.name === name ? activeStyle : inactiveStyle]}>
           <img css={imgStyle} src={profileImg ? profileImg : DEFAULT_PROFILE_IMG} alt={`${name}님의 프로필 이미지`} />
         </div>
       )}
@@ -45,14 +45,15 @@ const infoStyle = css`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 8px;
 `;
 
-const detailNameStyle = (theme: Theme) => css`
-  ${theme.typography.size_10}
-  width: 42px;
+const detailNameStyle = css`
+  font-size: 12px;
+  font-weight: 500;
+  width: 80px;
   text-align: center;
-  text-overflow: clip;
+  text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
 `;
@@ -61,28 +62,28 @@ const sidebarNameStyle = (theme: Theme) => css`
   ${theme.typography.size_16}
 `;
 
+const imgContainerStyle = css`
+  width: 88px;
+  height: 88px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 const imgStyle = (theme: Theme) => css`
-  width: 56px;
-  height: 56px;
+  width: 80px;
+  height: 80px;
   object-fit: cover;
   border-radius: 50%;
   border: 3.5px solid ${theme.colors.background.white};
 `;
 
 const activeStyle = css`
-  display: flex;
-  justify-content: center;
-  align-items: center;
   background: linear-gradient(90deg, rgb(255, 126, 0) 10%, rgba(255, 191, 0, 1) 72%, rgba(255, 246, 0, 1) 100%);
   border-radius: 50%;
-  width: 64px;
-  height: 64px;
 `;
 
 const inactiveStyle = css`
-  display: flex;
-  justify-content: center;
-  align-items: center;
   opacity: 50%;
 `;
 

--- a/src/components/Member/SquadDetailMemberList.tsx
+++ b/src/components/Member/SquadDetailMemberList.tsx
@@ -43,7 +43,6 @@ const Member = ({ member }: { member: SquadMember }) => {
 
 const containerStyle = css`
   display: flex;
-  gap: 8px;
   flex-wrap: nowrap;
   align-items: center;
   margin: 0 16px;


### PR DESCRIPTION
## 작업 사항
- 프로필 이미지 사이즈 조정
- 닉네임 최대 사이즈 제한 및 `text-overflow` 속성을 `clip`에서 `ellipsis`로 수정

## 관련 이슈
close #206 