### PR TITLE
Fix: 리더 위임을 위한 멤버 목록 스타일 깨짐

### DIFF
--- a/src/components/Member/SelectMemberList.tsx
+++ b/src/components/Member/SelectMemberList.tsx
@@ -74,7 +74,6 @@ const Member = ({ squadId, member }: { squadId: number; member: SquadMember }) =
     <>
       <li css={itemStyle}>
         <button onClick={handleSelectMember} style={fullSizeButtonStyle} aria-label={member.name}>
-          <MemberProfile member={member} displayRole={false} type={MEMBER_STYLE_TYPE.DEFAULT} />
           <IconWrapper
             aria-label={isChecked ? '선택된 멤버' : '선택되지 않은 멤버'}
             aria-checked={isChecked}
@@ -83,6 +82,7 @@ const Member = ({ squadId, member }: { squadId: number; member: SquadMember }) =
           >
             {isChecked && <Check />}
           </IconWrapper>
+          <MemberProfile member={member} displayRole={false} type={MEMBER_STYLE_TYPE.DEFAULT} />
         </button>
       </li>
       <AssignSquadLeaderModal />
@@ -95,18 +95,21 @@ const containerStyle = css`
 `;
 
 const itemStyle = css`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   cursor: pointer;
   padding: 8px;
+
+  & button {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
 
   & svg {
     stroke-width: 2.5;
   }
 
   :hover {
-    background-color: rgba(231, 201, 138, 0.3);
+    background-color: rgba(186, 186, 186, 0.3);
     border-radius: 12px;
   }
 `;


### PR DESCRIPTION
## 작업 사항
- button 태그에 flex 스타일 적용하여 레이아웃 조정

### 스크린샷
- before
<img width="529" alt="Image" src="https://github.com/user-attachments/assets/0838241b-81e2-437d-911f-e8145b9ee298" />

- after
<img width="532" alt="스크린샷 2025-02-19 오전 12 46 19" src="https://github.com/user-attachments/assets/e7982533-03f5-4589-a55e-53936b52c5fc" />

## 관련 이슈
close #209 