### PR TITLE
Fix: 모바일 레이아웃 깨짐 수정

### DIFF
--- a/src/Pages/SquadDetailPage.tsx
+++ b/src/Pages/SquadDetailPage.tsx
@@ -6,6 +6,7 @@ import { useUserCookie } from '@/hooks';
 import { squadDetailQueryOptions, todoInfiniteQueryOptions } from '@/hooks/queries';
 import { useDayStore, useMemberStore, useSquadStore } from '@/stores';
 import { pcMediaQuery } from '@/styles/breakpoints';
+import { ellipsisStyle } from '@/styles/globalStyles';
 import { css, Theme } from '@emotion/react';
 import { useInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
@@ -80,17 +81,27 @@ const SquadDetailPage = () => {
   return (
     <section css={containerStyle}>
       <Calendar onChangeSelectedDay={setSelectedDay} />
+
       <section aria-labelledby="squad-members">
         <h2 id="squad-members" className="sr-only">
           멤버
         </h2>
         <SquadDetailMemberList squadMembers={squadDetail.squadMembers} />
       </section>
-      <div css={headerStyle}>
-        <span>{selectedDay}</span>
-        <span>{!selectedMember ? user?.name : selectedMember.name}</span>
+
+      <header css={headerStyle}>
+        <span style={{ width: '90px' }}>{selectedDay}</span>
+        <span
+          css={ellipsisStyle}
+          style={{
+            width: '112px',
+          }}
+        >
+          {!selectedMember ? user?.name : selectedMember.name}
+        </span>
         <span css={completionRateStyle}>달성률: {progressRate}%</span>
-      </div>
+      </header>
+
       <TodoList
         todos={todos}
         loadMoreTodos={loadMoreTodos}
@@ -98,7 +109,15 @@ const SquadDetailPage = () => {
         isMeSelected={isMeSelected}
         squadMemberId={squadMemberId}
       />
-      {isMeSelected && <TodoForm squadId={squadId} selectedDay={selectedDay} squadMemberId={squadMemberId} />}
+
+      {isMeSelected && (
+        <section aria-labelledby="todo-form">
+          <h2 id="todo-form" className="sr-only">
+            투두 작성 폼
+          </h2>
+          <TodoForm squadId={squadId} selectedDay={selectedDay} squadMemberId={squadMemberId} />
+        </section>
+      )}
     </section>
   );
 };

--- a/src/Pages/SquadPage.tsx
+++ b/src/Pages/SquadPage.tsx
@@ -28,7 +28,7 @@ const SquadPage = () => {
     <>
       <div css={headerStyle}>
         <span>스쿼드</span>
-        <Button text="스쿼드 생성" onClick={handleCreateSquad} aria-label="스쿼드 생성" />
+        <Button text="스쿼드 생성" onClick={handleCreateSquad} customCss={createSquadButtonStyle} />
       </div>
       {squadList.length ? (
         <ul>
@@ -95,13 +95,6 @@ const headerStyle = (theme: Theme) => css`
     ${theme.typography.size_24};
     padding-left: 16px;
   }
-
-  & button {
-    width: 112px;
-    ${theme.typography.size_18};
-    background-color: var(--color-primary);
-    color: white;
-  }
 `;
 
 const blankStyle = css`
@@ -110,4 +103,12 @@ const blankStyle = css`
   & p {
     margin-bottom: 84px;
   }
+`;
+
+const createSquadButtonStyle = (theme: Theme) => css`
+  width: 112px;
+  ${theme.typography.size_16}
+  font-weight: 700;
+  background-color: var(--color-primary);
+  color: white;
 `;

--- a/src/components/Member/MemberProfile.tsx
+++ b/src/components/Member/MemberProfile.tsx
@@ -2,6 +2,7 @@ import { ROLE } from '@/constants/role';
 import { MEMBER_STYLE_TYPE } from '@/constants/squad';
 import { useUserCookie } from '@/hooks';
 import { pcMediaQuery } from '@/styles/breakpoints';
+import { ellipsisStyle } from '@/styles/globalStyles';
 import { SquadMember } from '@/types';
 import { css, Theme } from '@emotion/react';
 
@@ -27,7 +28,7 @@ const MemberProfile = ({ member, selectedMember, displayRole, type }: Props) => 
           <img css={imgStyle} src={profileImg ? profileImg : DEFAULT_PROFILE_IMG} alt={`${name}님의 프로필 이미지`} />
         </div>
       )}
-      <p css={isSquadDetail ? detailNameStyle : sidebarNameStyle}>
+      <p css={[isSquadDetail ? detailNameStyle : sidebarNameStyle, ellipsisStyle]}>
         {name}
         {displayRole && (
           <>
@@ -53,10 +54,6 @@ const detailNameStyle = css`
   font-size: 12px;
   font-weight: 500;
   width: 80px;
-  text-align: center;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
 `;
 
 const sidebarNameStyle = (theme: Theme) => css`

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, SerializedStyles, Theme } from '@emotion/react';
 import { ButtonHTMLAttributes } from 'react';
 
 type Variant = 'default' | 'primary' | 'confirm' | 'delete';
@@ -6,22 +6,22 @@ type Variant = 'default' | 'primary' | 'confirm' | 'delete';
 type ButtonProps = {
   text: string;
   variant?: Variant;
+  customCss?: (theme: Theme) => SerializedStyles;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
-const Button = ({ text, variant = 'default', onClick, ...rest }: ButtonProps) => (
-    <button css={[buttonStyle, getVariantStyles(variant)]} onClick={onClick} {...rest}>
-      {text}
-    </button>
-  );
+const Button = ({ text, variant = 'default', onClick, customCss, ...rest }: ButtonProps) => (
+  <button css={[buttonStyle, getVariantStyles(variant), customCss]} onClick={onClick} {...rest}>
+    {text}
+  </button>
+);
 
 export default Button;
 
-const buttonStyle = () => css`
+const buttonStyle = css`
   width: 100%;
   height: 36px;
   border-radius: 6px;
   font-weight: 700;
-
   :hover {
     opacity: 0.5;
   }

--- a/src/components/common/Calendar/Calendar.tsx
+++ b/src/components/common/Calendar/Calendar.tsx
@@ -112,7 +112,7 @@ Calendar.Item = forwardRef<HTMLLIElement, { day: string }>(({ day }, ref) => {
       aria-selected={selectedDay === day}
       id={`${day}일`}
     >
-      <button style={fullSizeButtonStyle} onClick={handleClick}>
+      <button style={fullSizeButtonStyle} onClick={handleClick} css={calendarButtonStyle}>
         <span>{format(new Date(day), 'dd')}</span>
         <span css={dayNameStyle}>{format(new Date(day), 'EEE', { locale: ko })}</span>
       </button>
@@ -152,6 +152,13 @@ const calendarItemStyle = (theme: Theme, isSelected: boolean) => css`
     background-color: ${!isSelected && theme.colors.background.yellow};
     cursor: ${isSelected && 'default'};
   }
+`;
+
+const calendarButtonStyle = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 `;
 
 const todayStyle = (theme: Theme, isSelected: boolean) => css`

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -235,3 +235,10 @@ export const scrollBarStyle = css`
 `;
 
 export const fullSizeButtonStyle = { width: '100%', height: '100%' };
+
+export const ellipsisStyle = css`
+  text-align: center;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+`;


### PR DESCRIPTION
## 작업 사항
- 모바일 레이아웃 깨짐 해결
   - `Calendar` 날짜가 모바일에서 가운데 정렬되도록 flex 속성 추가
- 스쿼드 상세 페이지 내 투두리스트 header 간격 수정
- `ellipsisStyle` globalStyles로 분리
- Button 공통 컴포넌트에 customCss 속성을 추가하여 스타일 확장성 개선

## 스크린샷
- 날짜 정렬
<img src="https://github.com/user-attachments/assets/f6759fa3-22a5-44f8-9346-27aa47e9e0d0" width="360px">
<br/>

- 여백 비율
<img src="https://github.com/user-attachments/assets/b6fc5899-1654-4136-be9b-b436838c383c" width="360px">

## 관련 이슈
close #222 