### PR TITLE
Fix: 투두 내용 수정 모드에서 Space 입력 시 상태 변경 문제 해결

### DIFF
--- a/src/components/Todo/Content.tsx
+++ b/src/components/Todo/Content.tsx
@@ -14,17 +14,17 @@ type Props = {
 const Content = ({ todo, isCompleted, updateActions }: Props) => {
   const { isEditMode, toggleTodoStatus } = updateActions;
 
+  if (isEditMode) {
+    return <EditMode updateActions={updateActions} />;
+  }
+
   return (
     <button onClick={toggleTodoStatus} css={fullSizeButtonStyle} aria-label="투두 상태 변경">
       <div css={contentWrapperStyle}>
         <Status isCompleted={isCompleted} />
-        {isEditMode ? (
-          <EditMode updateActions={updateActions} />
-        ) : (
-          <p id={`todo-${todo.toDoId}`} css={isCompleted && completedContentStyle} style={{ textAlign: 'left' }}>
-            {todo.contents}
-          </p>
-        )}
+        <p id={`todo-${todo.toDoId}`} css={isCompleted && completedContentStyle} style={{ textAlign: 'left' }}>
+          {todo.contents}
+        </p>
       </div>
     </button>
   );

--- a/src/components/Todo/EditMode.tsx
+++ b/src/components/Todo/EditMode.tsx
@@ -2,7 +2,7 @@ import { editInputStyle } from '@/components/Todo/styles';
 import { TodoUpdateActionsReturnType } from '@/hooks/todo';
 
 const EditMode = ({ updateActions }: { updateActions: TodoUpdateActionsReturnType }) => {
-  const { newContents, setNewContents, handleKeyPressForEdit } = updateActions;
+  const { newContents, setNewContents, handleKeyDownForEdit } = updateActions;
 
   return (
     <input
@@ -10,7 +10,7 @@ const EditMode = ({ updateActions }: { updateActions: TodoUpdateActionsReturnTyp
       value={newContents}
       onChange={(e) => setNewContents(e.target.value)}
       onClick={(e) => e.stopPropagation()}
-      onKeyDown={handleKeyPressForEdit}
+      onKeyDown={handleKeyDownForEdit}
       css={editInputStyle}
       autoFocus
     />

--- a/src/components/Todo/styles.tsx
+++ b/src/components/Todo/styles.tsx
@@ -121,6 +121,7 @@ export const actionStyle = css`
 
 export const editInputStyle = (theme: Theme) => css`
   height: 100%;
+  padding-left: 8px;
   flex: 1;
   font-size: 0.8rem;
   color: var(--color-text-gray);
@@ -131,7 +132,7 @@ export const editInputStyle = (theme: Theme) => css`
 `;
 
 export const editActionStyle = css`
-  width: 132px;
+  width: 112px;
   display: flex;
   gap: 4px;
   margin-right: 8px;

--- a/src/hooks/todo/useTodoUpdateActions.tsx
+++ b/src/hooks/todo/useTodoUpdateActions.tsx
@@ -13,7 +13,7 @@ export type TodoUpdateActionsReturnType = {
   setNewContents: Dispatch<SetStateAction<string>>;
   toggleTodoStatus: () => void;
   handleEditContents: () => void;
-  handleKeyPressForEdit: (e: KeyboardEvent<HTMLInputElement>) => void;
+  handleKeyDownForEdit: (e: KeyboardEvent<HTMLInputElement>) => void;
 };
 
 export const useTodoUpdateActions = (todo: ToDoDetail, queryParams: TodoQueryParams) => {
@@ -69,7 +69,7 @@ export const useTodoUpdateActions = (todo: ToDoDetail, queryParams: TodoQueryPar
     setIsEditMode(false);
   }, [contents, newContents, selectedDay, toDoId, updateTodoMutate]);
 
-  const handleKeyPressForEdit = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDownForEdit = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
       e.preventDefault();
       handleEditContents();
@@ -84,9 +84,9 @@ export const useTodoUpdateActions = (todo: ToDoDetail, queryParams: TodoQueryPar
       setNewContents,
       toggleTodoStatus,
       handleEditContents,
-      handleKeyPressForEdit,
+      handleKeyDownForEdit,
     }),
-    [isEditMode, newContents, toggleTodoStatus, handleEditContents, handleKeyPressForEdit],
+    [isEditMode, newContents, toggleTodoStatus, handleEditContents, handleKeyDownForEdit],
   );
 
   return todoUpdateActions;


### PR DESCRIPTION
## 작업 사항
### 문제 정의
- 투두 아이템에는 클릭 이벤트가 적용되어 li 태그 내부에 `<button>` 태그로 감싸도록 적용
   - `<input>`에서는 띄어쓰기를 하면 `<input>`이 `<button>` 내부에 있기때문에 <button>의 기본 동작이 먼저 적용되어 onClick이 실행 됨

### 원인
- `<button>` 태그는 기본적으로 Space와 Enter로 onClick 이벤트 트리거

### 해결 방법
#### 시도 01. 
```typescript
if (e.key === ' ') {
  e.stopPropagation();
}
```
- `<input>` 태그에 포커스 되어 있을 때, 키보드 이벤트 실행 시 버블링 방지
   - `<button>`의 기본 동작은 버블링이 아니라 브라우저 기본 동작으로 작동하므로, `e.stopPropagation()`만으로는 해결되지 않음

#### 시도 02.
```typescript
  if (e.key === ' ') {
    e.preventDefault(); 
  }
``` 
- `<button>`과 `<input>` 태그에 브라우저 기본 동작을 차단하면 상태 변경 안되지만, `<input>` 태그에서 띄어쓰기를 할 수 없음

#### 해결
`isEditMode` 상태에 따라 컴포넌트를 분리하여 수정 모드일 때는 `<button>`을 렌더링 하지 않고 `<input>`만 렌더링하도록 분리

## 관련 이슈
close #227 