### PR TITLE
Refactor: 투두 수정 로직 개선 및 상세 페이지 관련 컴포넌트 메모이제이션

### DIFF
--- a/src/Pages/SquadPage/index.tsx
+++ b/src/Pages/SquadPage/index.tsx
@@ -5,12 +5,13 @@ import SquadItem from '@/Pages/SquadPage/SquadItem';
 import { blankStyle, createSquadButtonStyle, headerStyle } from '@/Pages/SquadPage/style';
 import { useToastStore } from '@/stores';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const SquadPage = () => {
   const navigate = useNavigate();
   const createToast = useToastStore((state) => state.createToast);
-  const { data: squadList } = useSuspenseQuery(squadQueryOptions()).data;
+  const { data } = useSuspenseQuery(squadQueryOptions()).data;
   const { CreateSquadModal, handleCreateSquad } = useCreateSquad({
     onSuccess: async ({ data }) => {
       navigate(`/squads/${data.squadId}`);
@@ -21,21 +22,15 @@ const SquadPage = () => {
     },
   });
 
+  const squadList = useMemo(() => data.map((squad) => <SquadItem key={squad.squadId} squad={squad} />), [data]);
+
   return (
     <>
       <div css={headerStyle}>
         <span>스쿼드</span>
         <Button text="스쿼드 생성" onClick={handleCreateSquad} customCss={createSquadButtonStyle} />
       </div>
-      {squadList.length ? (
-        <ul>
-          {squadList.map((squad) => (
-            <SquadItem key={squad.squadId} squad={squad} />
-          ))}
-        </ul>
-      ) : (
-        <EmptyContent message="참여중인 스쿼드가 없어요" css={blankStyle} />
-      )}
+      {squadList.length ? <ul>{squadList}</ul> : <EmptyContent message="참여중인 스쿼드가 없어요" css={blankStyle} />}
       <CreateSquadModal />
     </>
   );

--- a/src/components/Member/SquadDetailMemberList.tsx
+++ b/src/components/Member/SquadDetailMemberList.tsx
@@ -5,6 +5,7 @@ import { useMemberStore } from '@/stores';
 import { fullSizeButtonStyle, scrollBarStyle } from '@/styles/globalStyles';
 import { SquadMember } from '@/types';
 import { css } from '@emotion/react';
+import { memo } from 'react';
 
 type Props = {
   squadMembers: SquadMember[];
@@ -23,7 +24,7 @@ const SquadDetailMemberList = ({ squadMembers }: Props) => {
   );
 };
 
-export default SquadDetailMemberList;
+export default memo(SquadDetailMemberList);
 
 const Member = ({ member }: { member: SquadMember }) => {
   const { selectedMember, setSelectedMember } = useMemberStore((state) => state);

--- a/src/components/Todo/List.tsx
+++ b/src/components/Todo/List.tsx
@@ -23,12 +23,9 @@ const List = ({ isMeSelected, onChangeProgressRate, queryParams }: Props) => {
     pageSize: TODO_PAGE_SIZE,
   };
 
-  const {
-    data,
-    fetchNextPage,
-    hasNextPage,
-    refetch: refetchTodos,
-  } = useInfiniteQuery(todoInfiniteQueryOptions(squadMemberId, squadId, selectedDay, payload));
+  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
+    todoInfiniteQueryOptions(squadMemberId, squadId, selectedDay, payload),
+  );
 
   const todos = data ?? [];
 
@@ -39,10 +36,6 @@ const List = ({ isMeSelected, onChangeProgressRate, queryParams }: Props) => {
   };
 
   const { loadMoreRef } = useInfinite(loadMoreTodos, hasNextPage);
-
-  useEffect(() => {
-    if (!data) refetchTodos();
-  }, [data]);
 
   useEffect(() => {
     const isCompleted = todos.filter((todo) => todo.toDoStatus === TODO_STATUS.COMPLETED).length;

--- a/src/components/Todo/List.tsx
+++ b/src/components/Todo/List.tsx
@@ -23,9 +23,12 @@ const List = ({ isMeSelected, onChangeProgressRate, queryParams }: Props) => {
     pageSize: TODO_PAGE_SIZE,
   };
 
-  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
-    todoInfiniteQueryOptions(squadMemberId, squadId, selectedDay, payload),
-  );
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    refetch: refetchTodos,
+  } = useInfiniteQuery(todoInfiniteQueryOptions(squadMemberId, squadId, selectedDay, payload));
 
   const todos = data ?? [];
 
@@ -36,6 +39,10 @@ const List = ({ isMeSelected, onChangeProgressRate, queryParams }: Props) => {
   };
 
   const { loadMoreRef } = useInfinite(loadMoreTodos, hasNextPage);
+
+  useEffect(() => {
+    if (!data) refetchTodos();
+  }, [data]);
 
   useEffect(() => {
     const isCompleted = todos.filter((todo) => todo.toDoStatus === TODO_STATUS.COMPLETED).length;

--- a/src/hooks/mutations/useUpdateTodo.tsx
+++ b/src/hooks/mutations/useUpdateTodo.tsx
@@ -23,17 +23,14 @@ export const useUpdateTodo = (
         queryClient,
         todoKeys.todosByMember(squadId, selectedDay, squadMemberId),
         (prevData: InfiniteQueryData<ApiResponse<ToDoDetail[]>>) => {
-          const todo = {
-            ...newTodo,
-            toDoId,
-          };
+          const updatedPages = prevData.pages.map((page) => ({
+            ...page,
+            data: page.data.map((prevTodo) => (prevTodo.toDoId === toDoId ? { ...prevTodo, ...newTodo } : prevTodo)),
+          }));
 
           return {
             ...prevData,
-            pages: prevData.pages.map((page) => ({
-              ...page,
-              data: page.data.map((prevTodo) => (prevTodo.toDoId === toDoId ? todo : prevTodo)),
-            })),
+            pages: updatedPages,
           };
         },
       );

--- a/src/hooks/todo/useTodoUpdateActions.tsx
+++ b/src/hooks/todo/useTodoUpdateActions.tsx
@@ -69,12 +69,15 @@ export const useTodoUpdateActions = (todo: ToDoDetail, queryParams: TodoQueryPar
     setIsEditMode(false);
   }, [contents, newContents, selectedDay, toDoId, updateTodoMutate]);
 
-  const handleKeyDownForEdit = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
-      e.preventDefault();
-      handleEditContents();
-    }
-  }, []);
+  const handleKeyDownForEdit = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+        e.preventDefault();
+        handleEditContents();
+      }
+    },
+    [newContents],
+  );
 
   const todoUpdateActions = useMemo(
     () => ({

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -38,12 +38,7 @@ export const useModal = () => {
             resolve({ ok: false, error: reason });
             closeModal();
           },
-          actionModal: actionModal && {
-            type: actionModal.type,
-            text: actionModal.text,
-            message: actionModal.message,
-            displayCancel: actionModal.displayCancel,
-          },
+          actionModal: actionModal ?? undefined,
         };
         open(modal);
       }),

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -9,8 +9,8 @@ export type OpenModalType = <
   },
 >(
   Component: ComponentType<P>,
-  props?: Omit<P, 'onSubmit' | 'onAbort'> | undefined,
-  actionModal?: ActionModalType,
+  props?: Omit<P, 'onSubmit' | 'onAbort'> | null,
+  actionModal?: ActionModalType | null,
 ) => Promise<{
   ok: boolean;
   value?: Parameters<P['onSubmit']>[0];
@@ -24,7 +24,7 @@ export const useModal = () => {
 
   const closeModal = useCallback(() => close(modalId), [modalId, close]);
   const openModal: OpenModalType = useCallback(
-    (Component, props?, actionModal?) =>
+    (Component, props = null, actionModal = null) =>
       new Promise((resolve) => {
         const modal = {
           element: Component,
@@ -38,7 +38,7 @@ export const useModal = () => {
             resolve({ ok: false, error: reason });
             closeModal();
           },
-          actionModal: actionModal ?? undefined,
+          actionModal: actionModal,
         };
         open(modal);
       }),

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -6,17 +6,17 @@ export type ActionStatus = 'confirm' | 'delete';
 export type ModalParameters = {
   onSubmit(value: unknown): unknown;
   onAbort(reason?: string): void;
-  props?: Record<string, unknown>;
-  actionModal?: ActionModalType;
+  props?: Record<string, unknown> | null;
+  actionModal?: ActionModalType | null;
 };
 
 export type ModalType<P> = {
   element: ComponentType<P>;
-  props?: Record<string, unknown>;
+  props?: Record<string, unknown> | null;
   modalId: string;
   resolve: <T extends object>(value?: T | PromiseLike<T>) => void;
   reject: (reason: string) => void;
-  actionModal?: ActionModalType;
+  actionModal?: ActionModalType | null;
 };
 
 export type OverlayProps = {


### PR DESCRIPTION
## 작업 사항
- `Enter`키로 투두 내용 수정 안됨 문제 해결
   - `useCallback`으로 감싼 투두 수정 이벤트 핸들러의 의존성에 `newContents` 추가
- 낙관적 업데이트 로직 개선
   - 수정하려는 투두의 캐시 데이터를 업데이트할 때, 수정 전 투두 객체를 참조하여 새로운 값으로 업데이트
- 투두 리스트 렌더링 시 불필요한 `refetch` 함수 호출 제거
- 상세 페이지 멤버 목록 `React.memo` 적용
- 불필요한 객체 생성 개선
   ```typescript
   //AS-IS
  actionModal: actionModal && {
    type: actionModal.type,
    text: actionModal.text,
    message: actionModal.message,
    displayCancel: actionModal.displayCancel,
  },
  
  //TO-BE
  actionModal: actionModal ?? undefined,
   ```

- 스쿼드 리스트 성능 최적화
   - `useMemo`로 스쿼드 생성 폼 입력 시 불필요한 리렌더링 방지


## 관련 이슈
close #229 